### PR TITLE
feat: Introduce smart recipe selector to prevent circular dependencies

### DIFF
--- a/src/hooks/useProductionPlan.ts
+++ b/src/hooks/useProductionPlan.ts
@@ -1,5 +1,6 @@
 import {
   calculateProductionPlan,
+  smartRecipeSelector,
   type UnifiedProductionPlan,
 } from "../lib/calculator";
 import { items, recipes, facilities } from "../data";
@@ -35,7 +36,7 @@ export function useProductionPlan() {
           recipes,
           facilities,
           recipeOverrides,
-          undefined,
+          smartRecipeSelector,
           manualRawMaterials,
         );
 


### PR DESCRIPTION
This commit introduces a new `smartRecipeSelector` to prevent infinite loops and circular dependencies when calculating a production plan.

The recipe selector uses the `visitedPath` (a set of item IDs currently in the dependency chain) to filter out recipes that would cause the dependency graph to circle back on itself.

close #5 