### PR TITLE
Refactor layout logic in dependency tree

### DIFF
--- a/src/components/production/ProductionViewTabs.tsx
+++ b/src/components/production/ProductionViewTabs.tsx
@@ -15,6 +15,7 @@ import type {
   VisualizationMode,
 } from "@/types";
 import type { ProductionLineData } from "./ProductionTable";
+import { ReactFlowProvider } from "@xyflow/react";
 
 interface ProductionViewTabsProps {
   plan: ProductionDependencyGraph | null;
@@ -95,12 +96,14 @@ export default function ProductionViewTabs({
               </div>
             </TabsContent>
             <TabsContent value="tree" className="h-full m-0">
-              <ProductionDependencyTree
-                plan={plan}
-                items={items}
-                facilities={facilities}
-                visualizationMode={visualizationMode}
-              />
+              <ReactFlowProvider>
+                <ProductionDependencyTree
+                  plan={plan}
+                  items={items}
+                  facilities={facilities}
+                  visualizationMode={visualizationMode}
+                />
+              </ReactFlowProvider>
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -47,9 +47,6 @@ export const preloadLayoutEngine = () => {
 // Start preloading immediately when this utility module is imported
 preloadLayoutEngine();
 
-const nodeWidth = 220;
-const nodeHeight = 110;
-
 /**
  * Lays out React Flow elements using the ELK algorithm.
  * ELK provides better handling of hierarchy and complex cycles than Dagre.
@@ -80,11 +77,13 @@ export const getLayoutedElements = async (
       "elk.layered.unnecessaryBendpoints": "true",
       "org.eclipse.elk.padding": "[top=40,left=40,bottom=40,right=40]",
     },
-    children: nodes.map((node) => ({
-      id: node.id,
-      width: nodeWidth,
-      height: nodeHeight,
-    })),
+    children: nodes.map((node) => {
+      return {
+        id: node.id,
+        width: node.measured?.width,
+        height: node.measured?.height,
+      };
+    }),
     edges: edges.map((edge) => {
       const isBackward =
         edge.type === "backwardEdge" || edge.data?.direction === "backward";


### PR DESCRIPTION
Move layout computation to a separate effect that runs after nodes are initialized. This ensures that layout is applied only when the React Flow component is ready and nodes have been rendered, preventing potential layout issues.

Add `ReactFlowProvider` to wrap the dependency tree component to ensure context is available.

close #14 