### PR TITLE
feat: add raw material usage breakdown in production stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -538,41 +541,49 @@ packages:
     resolution: {integrity: sha512-xlMh4gNtplNQEwuF5icm69udC7un0WyzT5ywOeHrPMEsghKnLjXok2wZgAA7ocTm9+JsI+nVXIQa5XO1x+HPQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.16.2':
     resolution: {integrity: sha512-OZs33QTMi0xmHv/4P0+RAKXJTBk7UcMH5tpTaCytWRXls/DGaJ48jOHmriQGK2YwUqXl+oneuNyPOUO0obJ+Hg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.16.2':
     resolution: {integrity: sha512-UVyuhaV32dJGtF6fDofOcBstg9JwB2Jfnjfb8jGlu3xcG+TsubHRhuTwQ6JZ1sColNT1nMxBiu7zdKUEZi1kwg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.16.2':
     resolution: {integrity: sha512-YZZS0yv2q5nE1uL/Fk4Y7m9018DSEmDNSG8oJzy1TJjA1jx5HL52hEPxi98XhU6OYhSO/vC1jdkJeE8TIHugug==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.16.2':
     resolution: {integrity: sha512-9VYuypwtx4kt1lUcwJAH4dPmgJySh4/KxtAPdRoX2BTaZxVm/yEXHq0mnl/8SEarjzMvXKbf7Cm6UBgptm3DZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.16.2':
     resolution: {integrity: sha512-3gbwQ+xlL5gpyzgSDdC8B4qIM4mZaPDLaFOi3c/GV7CqIdVJc5EZXW4V3T6xwtPBOpXPXfqQLbhTnUD4SqwJtA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.16.2':
     resolution: {integrity: sha512-m0WcK0j54tSwWa+hQaJMScZdWneqE7xixp/vpFqlkbhuKW9dRHykPAFvSYg1YJ3MJgu9ZzVNpYHhPKJiEQq57Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.16.2':
     resolution: {integrity: sha512-ZjUm3w96P2t47nWywGwj1A2mAVBI/8IoS7XHhcogWCfXnEI3M6NPIRQPYAZW4s5/u3u6w1uPtgOwffj2XIOb/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.16.2':
     resolution: {integrity: sha512-OFVQ2x3VenTp13nIl6HcQ/7dmhFmM9dg2EjKfHcOtYfrVLQdNR6THFU7GkMdmc8DdY1zLUeilHwBIsyxv5hkwQ==}
@@ -607,6 +618,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1064,24 +1088,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
     resolution: {integrity: sha512-MioXcCIX/wB1pBnBoJx8q4OGucUAfC1+/X1ilKFsjDK05VwbLZGRgOVD5OJJpUQPK86DhQciNBrfOKDiatxNmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
     resolution: {integrity: sha512-m66M61fizvRCwt5pOEiZQMiwBL9/y0bwU/+Kc4Ce/Pef6YfoEkR28y+DzN9rMdjo8Z28NXjsDPq9nH4mXnAP0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
     resolution: {integrity: sha512-yRxlSfBvWnnfrdtJfvi9lg8xfG5mPuyoSHm0X01oiE8ArmLRvoJGHUTJydCYz+wbK2esbq5J4B4Tq9WAsOlP1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
     resolution: {integrity: sha512-PHVxYhBpi8UViS3/hcvQQb9RFqCtvFmFU1PvUoTRiUdBtgHA6fONNHU4x796lgzNlVSD3DO/MZNk1s5/ozSMQg==}
@@ -1151,24 +1179,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.2':
     resolution: {integrity: sha512-5av6VYZZeneiYIodwzGMlnyVakpuYZryGzFIbgu1XP8wVylZxduEzup4eP8atiMDFmIm+s4wn8GySJmYqeJC0A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.2':
     resolution: {integrity: sha512-1nO/UfdCLuT/uE/7oB3EZgTeZDCIa6nL72cFEpdegnqpJVNDI6Qb8U4g/4lfVPkmHq2lvxQ0L+n+JdgaZLhrRA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.2':
     resolution: {integrity: sha512-Ksfrb0Tx310kr+TLiUOvB/I80lyZ3lSOp6cM18zmNRT/92NB4mW8oX2Jo7K4eVEI2JWyaQUAFubDSha2Q+439A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.2':
     resolution: {integrity: sha512-IzUb5RlMUY0r1A9IuJrQ7Tbts1wWb73/zXVXT8VhewbHGoNlBKE0qUhKMED6Tv4wDF+pmbtUJmKXDthytAvLmg==}
@@ -1241,24 +1273,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -2041,24 +2077,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3155,6 +3195,22 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:

--- a/public/locales/en/stats.json
+++ b/public/locales/en/stats.json
@@ -1,6 +1,8 @@
 {
   "powerUnit": "kW",
   "productionSteps": "Production Steps",
+  
+  "rawMaterialUsage": "Raw Material Usage",
   "rawMaterials": "Raw Materials",
   "title": "Production Statistics",
   "totalPower": "Total Power"

--- a/public/locales/es/stats.json
+++ b/public/locales/es/stats.json
@@ -1,1 +1,8 @@
-{ "powerUnit": "kW", "productionSteps": "Pasos de Producción", "rawMaterials": "Materias Primas", "title": "Estadísticas de Producción", "totalPower": "Energía Total" }
+{
+  "powerUnit": "kW",
+  "productionSteps": "Pasos de Producción",
+  "rawMaterialUsage": "Uso de Materias Primas",
+  "rawMaterials": "Materias Primas",
+  "title": "Estadísticas de Producción",
+  "totalPower": "Energía Total"
+}

--- a/public/locales/ja/stats.json
+++ b/public/locales/ja/stats.json
@@ -1,1 +1,8 @@
-{ "powerUnit": "kW", "productionSteps": "生産ステップ", "rawMaterials": "原材料", "title": "生産統計", "totalPower": "総消費電力" }
+{
+  "powerUnit": "kW",
+  "productionSteps": "生産ステップ",
+  "rawMaterialUsage": "原材料使用量",
+  "rawMaterials": "原材料",
+  "title": "生産統計",
+  "totalPower": "総消費電力"
+}

--- a/public/locales/ko/stats.json
+++ b/public/locales/ko/stats.json
@@ -1,1 +1,8 @@
-{ "powerUnit": "kW", "productionSteps": "생산 단계", "rawMaterials": "원자재", "title": "생산 통계", "totalPower": "총 전력" }
+{
+  "powerUnit": "kW",
+  "productionSteps": "생산 단계",
+  "rawMaterialUsage": "원자재 사용량",
+  "rawMaterials": "원자재",
+  "title": "생산 통계",
+  "totalPower": "총 전력"
+}

--- a/public/locales/ru/stats.json
+++ b/public/locales/ru/stats.json
@@ -1,1 +1,8 @@
-{ "powerUnit": "кВт", "productionSteps": "Этапы производства", "rawMaterials": "Сырьё", "title": "Статистика производства", "totalPower": "Общая энергия" }
+{
+  "powerUnit": "кВт",
+  "productionSteps": "Этапы производства",
+  "rawMaterialUsage": "Расход сырья",
+  "rawMaterials": "Сырьё",
+  "title": "Статистика производства",
+  "totalPower": "Общая энергия"
+}

--- a/public/locales/zh-Hans/stats.json
+++ b/public/locales/zh-Hans/stats.json
@@ -1,6 +1,7 @@
 {
   "powerUnit": "kW",
   "productionSteps": "生产步骤",
+  "rawMaterialUsage": "原材料用量",
   "rawMaterials": "原材料",
   "title": "生产统计",
   "totalPower": "总功耗"

--- a/public/locales/zh-Hant/stats.json
+++ b/public/locales/zh-Hant/stats.json
@@ -1,6 +1,7 @@
 {
   "powerUnit": "kW",
   "productionSteps": "生產步驟",
+  "rawMaterialUsage": "原材料用量",
   "rawMaterials": "原材料",
   "title": "生產統計",
   "totalPower": "總功耗"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ export default function App() {
               facilities={facilities}
               totalPowerConsumption={stats.totalPowerConsumption}
               productionSteps={stats.uniqueProductionSteps}
-              rawMaterialCount={stats.rawMaterialRequirements.size}
+              rawMaterialRequirements={stats.rawMaterialRequirements}
               facilityRequirements={stats.facilityRequirements}
               error={error}
               onTargetChange={handleTargetChange}

--- a/src/components/panels/LeftPanel.tsx
+++ b/src/components/panels/LeftPanel.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import TargetItemsGrid, { type ProductionTarget } from "./TargetItemsGrid";
 import ProductionStats from "../production/ProductionStats";
-import type { Facility, Item } from "@/types";
+import type { Facility, Item, ItemId } from "@/types";
 import { useTranslation } from "react-i18next";
 
 type LeftPanelProps = {
@@ -11,7 +11,7 @@ type LeftPanelProps = {
   facilities: Facility[];
   totalPowerConsumption: number;
   productionSteps: number;
-  rawMaterialCount: number;
+  rawMaterialRequirements: Map<ItemId, number>;
   facilityRequirements: Map<string, number>;
   error: string | null;
   onTargetChange: (index: number, rate: number) => void;
@@ -25,7 +25,7 @@ const LeftPanel = memo(function LeftPanel({
   facilities,
   totalPowerConsumption,
   productionSteps,
-  rawMaterialCount,
+  rawMaterialRequirements,
   facilityRequirements,
   error,
   onTargetChange,
@@ -58,9 +58,10 @@ const LeftPanel = memo(function LeftPanel({
       <ProductionStats
         totalPowerConsumption={totalPowerConsumption}
         productionSteps={productionSteps}
-        rawMaterialCount={rawMaterialCount}
+        rawMaterialRequirements={rawMaterialRequirements}
         facilityRequirements={facilityRequirements}
         facilities={facilities}
+        items={items}
         error={error}
       />
     </div>

--- a/src/components/production/ProductionStats.tsx
+++ b/src/components/production/ProductionStats.tsx
@@ -1,29 +1,52 @@
-import { memo } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { AlertCircle } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { AlertCircle, ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import type { Facility } from "@/types";
-import { getFacilityName } from "@/lib/i18n-helpers";
+import type { Facility, Item, ItemId } from "@/types";
+import { getFacilityName, getItemName } from "@/lib/i18n-helpers";
 
 type ProductionStatsProps = {
   totalPowerConsumption: number;
   productionSteps: number;
-  rawMaterialCount: number;
+  rawMaterialRequirements: Map<ItemId, number>;
   facilityRequirements: Map<string, number>;
   facilities: Facility[];
+  items: Item[];
   error: string | null;
 };
 
 const ProductionStats = memo(function ProductionStats({
   totalPowerConsumption,
   productionSteps,
-  rawMaterialCount,
+  rawMaterialRequirements,
   facilityRequirements,
   facilities,
+  items,
   error,
 }: ProductionStatsProps) {
   const { t } = useTranslation("stats");
+  const [rawMaterialsOpen, setRawMaterialsOpen] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const handleRawMaterialsToggle = useCallback((open: boolean) => {
+    setRawMaterialsOpen(open);
+    if (open) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          scrollRef.current?.scrollTo({
+            top: scrollRef.current.scrollHeight,
+            behavior: "smooth",
+          });
+        });
+      });
+    }
+  }, []);
 
   const facilityList = Array.from(facilityRequirements.entries())
     .map(([facilityId, count]) => {
@@ -35,12 +58,22 @@ const ProductionStats = memo(function ProductionStats({
     )
     .sort((a, b) => a.facility.id.localeCompare(b.facility.id));
 
+  const rawMaterialList = Array.from(rawMaterialRequirements.entries())
+    .map(([itemId, rate]) => {
+      const item = items.find((i) => i.id === itemId);
+      return item ? { item, rate } : null;
+    })
+    .filter(
+      (entry): entry is { item: Item; rate: number } => entry !== null,
+    )
+    .sort((a, b) => getItemName(a.item).localeCompare(getItemName(b.item)));
+
   return (
-    <Card className="shrink-0 border-border/50">
-      <CardHeader>
+    <Card className="min-h-0 flex flex-col border-border/50">
+      <CardHeader className="shrink-0">
         <CardTitle className="text-base">{t("title")}</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-2.5">
+      <CardContent ref={scrollRef} className="space-y-2.5 overflow-y-auto min-h-0">
         {error ? (
           <div className="flex items-center gap-2 text-destructive text-sm p-3 bg-destructive/10 rounded">
             <AlertCircle className="h-4 w-4 shrink-0" />
@@ -73,7 +106,7 @@ const ProductionStats = memo(function ProductionStats({
                   {t("rawMaterials")}
                 </div>
                 <div className="text-lg font-bold font-mono">
-                  {rawMaterialCount}
+                  {rawMaterialRequirements.size}
                 </div>
               </div>
             </div>
@@ -105,6 +138,52 @@ const ProductionStats = memo(function ProductionStats({
                     </div>
                   ))}
                 </div>
+              </>
+            )}
+
+            {rawMaterialList.length > 0 && (
+              <>
+                <Separator />
+                <Collapsible
+                  open={rawMaterialsOpen}
+                  onOpenChange={handleRawMaterialsToggle}
+                >
+                  <CollapsibleTrigger className="flex w-full items-center gap-1.5 text-sm font-medium hover:text-foreground/80 transition-colors cursor-pointer">
+                    <ChevronRight
+                      className={`h-4 w-4 shrink-0 transition-transform duration-200 ${rawMaterialsOpen ? "rotate-90" : ""}`}
+                    />
+                    {t("rawMaterialUsage")}
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <div className="grid grid-cols-2 gap-2 pt-2">
+                      {rawMaterialList.map(({ item, rate }) => (
+                        <div
+                          key={item.id}
+                          className="space-y-0.5 p-2 border border-border/50 bg-card"
+                        >
+                          <div className="flex items-center gap-1.5">
+                            {item.iconUrl && (
+                              <img
+                                src={item.iconUrl}
+                                alt={getItemName(item)}
+                                className="w-4 h-4 object-contain"
+                              />
+                            )}
+                            <div className="text-xs text-muted-foreground truncate flex-1">
+                              {getItemName(item)}
+                            </div>
+                          </div>
+                          <div className="text-sm font-semibold font-mono">
+                            {rate.toFixed(1)}
+                            <span className="text-xs font-normal text-muted-foreground ml-1">
+                              /min
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
               </>
             )}
           </>

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,7 @@
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+const Collapsible = CollapsiblePrimitive.Root;
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };


### PR DESCRIPTION
**Summary**

- Add a collapsible "Raw Material Usage" section to the Production Statistics panel that displays each raw material with its icon, name, and consumption rate (/min)
- Uses the existing `rawMaterialRequirements` data already computed by the production planner — now passed through to the UI instead of just the count
- Includes i18n translations for all 7 supported languages (en, es, ja, ko, ru, zh-Hans, zh-Hant)

**Details**

Previously the stats panel only showed the **number** of distinct raw materials. This change expands on that by letting users click to reveal the full breakdown, which materials and how much of each is needed per minute. This is especially useful for checking raw material totals while in Dependency Tree view.

<img width="442" height="156" alt="image" src="https://github.com/user-attachments/assets/c7fb666f-5d76-4c63-885d-8305aad77dc3" />

**Changes**

- **New dependency**: `@radix-ui/react-collapsible` + shadcn/ui `Collapsible` wrapper component
- **`ProductionStats`**: accepts the full `rawMaterialRequirements` map and `items` list; renders a collapsible grid of material cards with icons and rates
- **`LeftPanel` / `App`**: updated prop plumbing to pass `rawMaterialRequirements` map (replacing `rawMaterialCount`) and `items`
- **Locale files**: added `rawMaterialUsage` translation key across all 7 languages; also reformatted single-line JSON files to multi-line for consistency