### PR TITLE
Refactor: extract SCC solver disposal filter and overdetermined solve helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,15 +26,39 @@ pnpm vitest run src/tests/lib/calculator.test.ts
 
 ### Core Algorithm (`src/lib/calculator.ts`)
 
-The central piece of the codebase. Implements a graph-based production planner:
+The central piece of the codebase. Implements a graph-based production planner.
 
-1. **Bipartite graph** — items and recipes as two node types, connected by consumption/production edges
-2. **SCC detection** — Tarjan's algorithm finds circular production dependencies
-3. **Condensed DAG** — SCCs are collapsed into super-nodes, topologically sorted
-4. **Flow calculation** — walks the DAG; within SCCs, solves a linear system (Gaussian elimination in `linear-solver.ts`) to determine internal flow rates
-5. **Backtracking** — when multiple recipes exist for an item, tries alternatives if a chosen recipe leads to an invalid SCC solution
+**Pipeline** (`calculateProductionPlan`, outer loop runs up to 100 iterations for backtracking):
 
-The output is a `ProductionDependencyGraph` (nodes + edges with flow rates).
+1. **Build bipartite graph** (`buildBipartiteGraph`) — DFS from each target. Items + recipes as two node types. For each item pick one recipe via `selectRecipe` heuristic: prefer single-output recipes, prefer non-circular (not consuming `visitedPath`), else first. Respects `recipeOverrides` (user-pinned) and `recipeConstraints` (backtrack exclusions). Forced raw materials (`forcedRawMaterials` + `manualRawMaterials`) terminate recursion. Byproducts added to graph as non-raw nodes but NOT marked visited — lets them be re-discovered with external producers.
+
+2. **SCC detection** (`detectSCCs`) — Tarjan on bipartite graph. Successors: item → consuming recipes, recipe → output items. Each SCC captures items, recipes, and `externalInputs` (inputs from recipes outside SCC).
+
+3. **Condensed DAG + topo sort** (`buildCondensedDAGAndSort`) — collapse each SCC into one super-node. Kahn's algorithm topologically orders.
+
+4. **Flow calculation** (`calculateFlows`, reverse topo order so consumers processed before producers):
+   - **Plain recipe node**: facility count = max over outputs of `demand / ratePerFacility`. Propagate input demand `= calcRate(input.amount, craftingTime) * facilityCount` to `itemDemands`.
+   - **SCC node**: delegate to `solveSCCFlow`. If fails, record in `invalidSCCs`.
+
+5. **SCC solver** (`solveSCCFlow`, 5 phases):
+   - Phase 1: external demands for internal items (external consumers + target rates).
+   - Phase 2: external-output demands — SCC recipes producing items OUTSIDE the SCC with non-zero demand. Pins those recipes' facility counts to `demand / rate`.
+   - Phase 3: build `n × m` matrix of net production coefficients `calcRate(output, t) - calcRate(input, t)` per (item, recipe). Before solving, drop impossible disposal-item rows via `filterImpossibleDisposalRows` (forced-disposal item with all-zero LHS + non-zero RHS — surplus handled later by `injectDisposalRecipes`). If any pinned, substitute their contribution into RHS and solve reduced system on `freeM` free recipes via `solveOverdetermined` (linear-solver.ts): `numVars == 0` → `[]`; overdetermined + 1 free var → `max(b/a)`; overdetermined multi-var → pick `numVars` rows with largest `|RHS|` and solve that square system; else plain `solveLinearSystem`. Fallback on no-solution → `tryExtendSCCWithFeeders`.
+   - Phase 4: deficit propagation. For each internal item compute net production, if `externalDemand - netProduction > 0` push deficit into `itemDemands` (via `Math.max`, NOT addition — external demand already counted in Phase 1).
+   - Phase 5: propagate consumption back to `scc.externalInputs` (demand += consumption).
+
+6. **Feeder extension** (`tryExtendSCCWithFeeders`) — fallback when SCC unsolvable. For each overridden item in SCC, find alternate non-SCC producing recipe (feeder) with at least one non-SCC input. Adds feeders to graph + SCC, pins the override recipe to its external demand, solves extended system. Validates: if target item still has deficit, rollback all mutations (`addedRecipeIds`, `addedItemIds`, `addedConsumptionEdges`, original `scc.recipes`/`externalInputs` sets) and return false. On success adds `scc.id` to `resolvedSCCIds` (cycle linearized — excluded from `detectedCycles`).
+
+7. **Disposal injection** (`injectDisposalRecipes`) — for each `forcedDisposalItems` with surplus (`production - consumption - targetDemand > 0`), find disposal recipe (empty outputs), add to graph with `facilityCount = surplus / rate`.
+
+8. **Backtracking** (`backtrackRecipeChoices`) — when `invalidSCCs` non-empty, collect items in those SCCs with `recipeChoices` (multiple options), pick one with next untried recipe, extend `recipeConstraints` excluding all recipes up to current index, rerun. Gives up when all combos exhausted → returns best-effort graph with `invalidCycles`.
+
+9. **Build final graph** (`buildProductionGraph`) — assemble `ProductionDependencyGraph` with nodes (sum production across ALL producing recipes for multi-producer items), edges (item↔recipe both directions), `detectedCycles` (excluding resolved SCCs), `invalidCycles`.
+
+**Invariants**:
+- Pool capacity / item production is tracked in primary-output units (first output). Byproducts computed via ratio `byproductAmount / primaryAmount`.
+- `itemDemands` uses `Math.max` for deficit, `+=` for external-input consumption and plain recipe inputs.
+- `resolvedSCCIds` filters `detectedCycles` so linearized cycles don't render backward edges.
 
 ### Data Flow
 
@@ -49,10 +73,56 @@ User selects targets + rates
 
 ### Two Visualization Paths
 
-- **Merged mapper** (`src/components/mappers/merged-mapper.ts`) — aggregates identical recipes, shows facility counts per recipe
-- **Separated mapper** (`src/components/mappers/separated-mapper.ts`) — individual facility instances with capacity allocation
+Both transform `ProductionDependencyGraph` → React Flow `{nodes, edges}`. Both use ELK (`src/lib/layout.ts`) for hierarchical graph layout, preloaded at startup.
 
-Both use ELK (`src/lib/layout.ts`) for hierarchical graph layout, preloaded at startup.
+#### Merged mapper (`merged-mapper.ts`)
+
+One node per recipe, annotated with `facilityCount`. Pipeline:
+
+1. **Create recipe flow nodes** — skip terminal recipes (no consumers, no secondary outputs — their output rendered in target sink instead). Rate per node = `calcRate(output.amount, craftingTime) * facilityCount` for THIS recipe's output (NOT total item production — multi-producer items split per-recipe).
+
+2. **Greedy allocation** (`computeGreedyAllocation` from `plan-helpers`) — multi-producer items (2+ non-disposal producers): collect all consumers with their demand, cascade whole producer outputs to consumers to minimize pipe connections. For multi-producer target items: target sink prepended to consumer list so override recipe goes to target first, feeders go to internal consumers (avoids visual cycles).
+
+3. **Item → Recipe edges** — if greedy allocation exists, emit one edge per `(producerRecipeId, consumerId)` pair. Else single producer → one edge at full rate. Raw material → create `rawMaterialId` node, edge from it. Terminal target recipes redirect edge target to `targetSinkId`.
+
+4. **Target sink nodes** — one per target item. Embed producer recipe info only if exactly one producer AND no separate flow node exists (terminal single-recipe target). Edges created when non-terminal OR any producer already has flow node (byproduct scenario).
+
+5. **Disposal sink nodes** — per disposal recipe. Edges from producers use `greedy.remainingByProducer` if greedy exists (remaining after consumer allocation), else proportional split by producer rate.
+
+#### Separated mapper (`separated-mapper.ts`)
+
+One node per physical facility instance via `CapacityPoolManager`. Pipeline:
+
+1. **Create pools** — per recipe, pool sized by `perRecipeRate = calcRate(output.amount, t) * facilityCount`.
+
+2. **Cycle detection prebuild** — `cyclePairs = Set<"recipeA:recipeB">` from `plan.detectedCycles`. Used to tag edges as `"backward"` when producer + consumer in same SCC.
+
+3. **Allocate upstream** (`allocateUpstream`, recursive) — for each demand: raw material → `ensurePickupPointNodes` (multiple pickup points per `getPickupPointCount(totalDemand, item)`, each capped by `getTransportCapacity`). Else sort producers by rate desc, greedy cascade, track `actuallyAllocated` (not requested) so deficit flows to next producer — prevents backward-byproduct exhaustion from stalling demand.
+
+4. **Pool allocation** (`allocateFromPool`):
+   - Primary-output demand: `poolManager.allocate(recipeId, demand)`.
+   - **Byproduct demand** (`demandedItemId !== primaryOutputId`): convert to pool units via `conversionRatio = byproductAmount / primaryAmount`, `poolDemandRate = demand / ratio`.
+     - `backward` direction: `allocateByproduct(..., forceRunning=true)` — NEVER consume primary capacity. Facilities guaranteed by SCC solver; prevents the double-allocation bug (cf. PR #53) where backward sewage consumed primary Xircon capacity.
+     - Forward: `allocateByproduct` first (free from running facilities), then `allocate` for remainder to activate new facilities.
+   - On first visit to a facility instance (`!isProcessed`): create flow node for primary output, recursively `allocateUpstream` for recipe inputs (scaled by `actualOutputRate / primaryOutputRate`).
+   - Return actual allocated (in demanded-item units) so caller can cascade remainder.
+
+5. **Main recipe pass** — iterate non-terminal recipes, force-create flow nodes for unprocessed facility instances + allocate their upstream. Terminal recipes skipped (target sink pass handles them).
+
+6. **Target sink pass** — three branches per target item:
+   - **Byproduct target** (producer already processed): allocate per-facility byproduct via `calcByproductRate(recipe, itemId, actualOutputRate)`. Greedy fill: `Math.min(byproductRate, remainingDemand)` per facility. Write into `byproductAllocatedToTarget` so disposal pass subtracts. Sink WITHOUT production info.
+   - **Terminal + multi-facility**: split into per-facility flow nodes with `isDirectTarget=true`, edges to sink, allocate inputs per facility.
+   - **Else**: sink with production info. Terminal single-facility → `allocateUpstream` inputs to sink. Non-terminal → `allocateFromPool` producer pool to sink.
+
+7. **Disposal pass** — per disposal recipe, compute per-facility byproduct rate, subtract `byproductAllocatedToTarget[facilityId:itemId]`, emit edge with remaining if `> 0.01`.
+
+**Shared helpers** (`src/lib/plan-helpers.ts`):
+- `getItemProducers(plan, itemId)` — all recipes producing item with per-recipe rate.
+- `getRecipeOutputItemId` — primary output (first non-disposal).
+- `isRecipeTerminal` — recipe has no downstream consumers for any output.
+- `computeGreedyAllocation(producers, consumers)` — merged mapper's whole-producer-to-consumer cascade.
+
+**Key invariant**: merged + separated mappers MUST agree on per-recipe rate (`calcRate(output, t) * facilityCount`). Changes to production rate computation in one require matching change in the other.
 
 ### Type System
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -8,6 +8,7 @@ const forcedRawMaterials = new Set<ItemId>([
   "item_quartz_sand",
   "item_iron_ore",
   "item_liquid_water",
+  "item_liquid_acid",
 ]);
 
 const MAX_TARGETS = 12;
@@ -20,4 +21,11 @@ const forcedDisposalItems = new Set<ItemId>([
   "item_liquid_xiranite_poly",
 ]);
 
-export { items, facilities, recipes, forcedRawMaterials, forcedDisposalItems, MAX_TARGETS };
+export {
+  items,
+  facilities,
+  recipes,
+  forcedRawMaterials,
+  forcedDisposalItems,
+  MAX_TARGETS,
+};

--- a/src/lib/calculator.ts
+++ b/src/lib/calculator.ts
@@ -11,13 +11,38 @@ import type {
   ProductionDependencyGraph,
   ProductionGraphNode,
 } from "@/types";
-import { solveLinearSystem } from "./linear-solver";
+import { solveOverdetermined } from "./linear-solver";
 import { forcedRawMaterials, forcedDisposalItems } from "@/data";
 import { calcRate } from "@/lib/utils";
 
+type SystemRow = { row: number[]; rhs: number; itemId: ItemId };
+
+// Drop rows for forced-disposal items whose LHS is all-zero with a non-zero RHS:
+// such equations are unsatisfiable in the linear system but the surplus they
+// represent is handled later by injectDisposalRecipes, so we must not let them
+// force the solver into "no solution".
+const filterImpossibleDisposalRows = (rows: SystemRow[]): SystemRow[] =>
+  rows.filter(
+    ({ row, rhs, itemId }) =>
+      !forcedDisposalItems.has(itemId) ||
+      row.some((v) => Math.abs(v) > 1e-9) ||
+      Math.abs(rhs) < 1e-9,
+  );
+
+// Dismantler recipes consume fbottle_* items (bottled products) as inputs.
+// They are reverse/recovery recipes and should be deprioritized during auto-selection
+// to avoid creating spurious bottle ↔ fbottle ↔ liquid cycles in the dependency graph.
+const isDismantleRecipe = (r: Recipe): boolean =>
+  r.inputs.some((i) => i.itemId.startsWith("item_fbottle_"));
+
 const selectRecipe = (recipes: Recipe[], visitedPath: Set<ItemId>): Recipe => {
+  // Prefer synthesis recipes over dismantle/recovery recipes.
+  // Fall back to full candidate list only if all recipes are dismantle type.
+  const nonDismantle = recipes.filter((r) => !isDismantleRecipe(r));
+  const pool = nonDismantle.length > 0 ? nonDismantle : recipes;
+
   // Priority 1: Recipes with single output (no byproducts)
-  const singleOutput = recipes.filter((r) => r.outputs.length === 1);
+  const singleOutput = pool.filter((r) => r.outputs.length === 1);
 
   if (singleOutput.length > 0) {
     // Priority 2: Among single-output recipes, prefer non-circular ones
@@ -37,7 +62,7 @@ const selectRecipe = (recipes: Recipe[], visitedPath: Set<ItemId>): Recipe => {
 
   // Priority 4: If no single-output recipes, prefer non-circular
   if (visitedPath.size > 0) {
-    const nonCircular = recipes.filter(
+    const nonCircular = pool.filter(
       (r) => !r.inputs.some((input) => visitedPath.has(input.itemId)),
     );
 
@@ -47,7 +72,7 @@ const selectRecipe = (recipes: Recipe[], visitedPath: Set<ItemId>): Recipe => {
   }
 
   // Priority 5: Default to first available recipe
-  return recipes[0];
+  return pool[0];
 };
 
 type ProductionMaps = {
@@ -549,7 +574,10 @@ function calculateFlows(
     }
   });
 
-  return { flowData: { itemDemands, recipeFacilityCounts, resolvedSCCIds }, invalidSCCs };
+  return {
+    flowData: { itemDemands, recipeFacilityCounts, resolvedSCCIds },
+    invalidSCCs,
+  };
 }
 
 function solveSCCFlow(
@@ -653,7 +681,14 @@ function solveSCCFlow(
     console.log(`  [SCC_SOLVE] No external demand, this is an invalid cycle`);
     // Try feeder extension before giving up
     return tryExtendSCCWithFeeders(
-      scc, graph, itemDemands, recipeFacilityCounts, maps, recipeOverrides, resolvedSCCIds, manualRawMaterials,
+      scc,
+      graph,
+      itemDemands,
+      recipeFacilityCounts,
+      maps,
+      recipeOverrides,
+      resolvedSCCIds,
+      manualRawMaterials,
     );
   }
 
@@ -685,18 +720,11 @@ function solveSCCFlow(
     );
     const freeM = freeIndices.length;
 
-    console.log(
-      `  Building reduced system: ${n} items × ${freeM} free recipes (${pinnedRecipes.size} pinned)`,
-    );
-
-    const matrix: number[][] = [];
-    const constants: number[] = [];
+    const rawRows: SystemRow[] = [];
 
     for (let i = 0; i < n; i++) {
       const itemId = itemsList[i];
       const row = new Array(freeM).fill(0);
-
-      // Start with external demand
       let rhs = externalDemands.get(itemId) || 0;
 
       for (let j = 0; j < m; j++) {
@@ -705,10 +733,11 @@ function solveSCCFlow(
           recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
         const input =
           recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
-        const coeff = calcRate(output, recipe.craftingTime) - calcRate(input, recipe.craftingTime);
+        const coeff =
+          calcRate(output, recipe.craftingTime) -
+          calcRate(input, recipe.craftingTime);
 
         if (pinnedRecipes.has(j)) {
-          // Move pinned contribution to RHS
           rhs -= coeff * pinnedRecipes.get(j)!;
         } else {
           const freeIdx = freeIndices.indexOf(j);
@@ -716,58 +745,40 @@ function solveSCCFlow(
         }
       }
 
-      matrix.push(row);
-      constants.push(rhs);
+      rawRows.push({ row, rhs, itemId });
+    }
 
+    const filteredRows = filterImpossibleDisposalRows(rawRows);
+    const matrix = filteredRows.map((e) => e.row);
+    const constants = filteredRows.map((e) => e.rhs);
+    const effectiveN = filteredRows.length;
+
+    console.log(
+      `  Building reduced system: ${effectiveN} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${n - effectiveN} disposal rows filtered)`,
+    );
+    filteredRows.forEach(({ row, rhs, itemId }, i) => {
       console.log(
         `    Equation ${i} (${itemId}):`,
         row.map((v, fi) => `${v.toFixed(2)}*r${freeIndices[fi]}`).join(" + "),
         `= ${rhs.toFixed(4)}`,
       );
-    }
+    });
 
-    // Solve the reduced system
-    let freeSolution: number[] | null;
-    if (freeM === 0) {
-      // All recipes are pinned — no system to solve
-      freeSolution = [];
-    } else if (n > freeM) {
-      // Overdetermined system (more equations than free variables).
-      // The linear solver expects a square matrix, so we solve for the
-      // maximum required facility counts to satisfy the tightest constraints.
-      // Deficits in other equations are handled by Phase 4 (external supply).
-      if (freeM === 1) {
-        // Single free variable: take the max of b/a across all equations
-        let maxR = 0;
-        for (let i = 0; i < n; i++) {
-          const a = matrix[i][0];
-          const b = constants[i];
-          if (Math.abs(a) > 1e-9) {
-            const r = b / a;
-            if (r > maxR) maxR = r;
-          }
-        }
-        freeSolution = [maxR];
-        console.log(
-          `  Overdetermined 1-var system: solved r = ${maxR.toFixed(4)}`,
-        );
-      } else {
-        // Multi-variable overdetermined: use first freeM equations as primary
-        // and compute residuals for the rest.
-        const subMatrix = matrix.slice(0, freeM);
-        const subConstants = constants.slice(0, freeM);
-        freeSolution = solveLinearSystem(subMatrix, subConstants);
-      }
-    } else {
-      freeSolution = solveLinearSystem(matrix, constants);
-    }
+    const freeSolution = solveOverdetermined(matrix, constants, freeM);
 
     if (!freeSolution) {
       console.warn(
         `  [SCC_SOLVE] Cannot solve reduced SCC ${scc.id} - system has no solution`,
       );
       return tryExtendSCCWithFeeders(
-        scc, graph, itemDemands, recipeFacilityCounts, maps, recipeOverrides, resolvedSCCIds, manualRawMaterials,
+        scc,
+        graph,
+        itemDemands,
+        recipeFacilityCounts,
+        maps,
+        recipeOverrides,
+        resolvedSCCIds,
+        manualRawMaterials,
       );
     }
 
@@ -787,15 +798,13 @@ function solveSCCFlow(
       );
     }
   } else {
-    // No pinned recipes — standard linear system solve (original path)
-    console.log(`  Building linear system: ${n} items × ${m} recipes`);
-
-    const matrix: number[][] = [];
-    const constants: number[] = [];
+    // No pinned recipes — standard linear system solve.
+    const rawRows: SystemRow[] = [];
 
     for (let i = 0; i < n; i++) {
       const itemId = itemsList[i];
       const row = new Array(m).fill(0);
+      const rhs = externalDemands.get(itemId) || 0;
 
       for (let j = 0; j < m; j++) {
         const recipe = recipesList[j];
@@ -803,27 +812,48 @@ function solveSCCFlow(
           recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
         const input =
           recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
-        row[j] = calcRate(output, recipe.craftingTime) - calcRate(input, recipe.craftingTime);
+        row[j] =
+          calcRate(output, recipe.craftingTime) -
+          calcRate(input, recipe.craftingTime);
       }
 
-      matrix.push(row);
-      constants.push(externalDemands.get(itemId) || 0);
+      rawRows.push({ row, rhs, itemId });
+    }
 
+    const filteredRows = filterImpossibleDisposalRows(rawRows);
+    const matrix = filteredRows.map((e) => e.row);
+    const constants = filteredRows.map((e) => e.rhs);
+    const effectiveN = filteredRows.length;
+
+    console.log(
+      `  Building linear system: ${effectiveN} items × ${m} recipes (${n - effectiveN} disposal rows filtered)`,
+    );
+    filteredRows.forEach(({ row, rhs, itemId }, i) => {
       console.log(
         `    Equation ${i} (${itemId}):`,
         row.map((v, j) => `${v.toFixed(2)}*r${j}`).join(" + "),
-        `= ${constants[i].toFixed(4)}`,
+        `= ${rhs.toFixed(4)}`,
       );
-    }
+    });
 
-    const solution = solveLinearSystem(matrix, constants);
+    const solution =
+      effectiveN === 0
+        ? new Array(m).fill(0)
+        : solveOverdetermined(matrix, constants, m);
 
     if (!solution) {
       console.warn(
         `  [SCC_SOLVE] Cannot solve SCC ${scc.id} - system has no solution`,
       );
       return tryExtendSCCWithFeeders(
-        scc, graph, itemDemands, recipeFacilityCounts, maps, recipeOverrides, resolvedSCCIds, manualRawMaterials,
+        scc,
+        graph,
+        itemDemands,
+        recipeFacilityCounts,
+        maps,
+        recipeOverrides,
+        resolvedSCCIds,
+        manualRawMaterials,
       );
     }
 
@@ -854,7 +884,8 @@ function solveSCCFlow(
         recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
 
       netProduction +=
-        (calcRate(output, recipe.craftingTime) - calcRate(input, recipe.craftingTime)) *
+        (calcRate(output, recipe.craftingTime) -
+          calcRate(input, recipe.craftingTime)) *
         facilityCount;
     }
 
@@ -867,10 +898,7 @@ function solveSCCFlow(
       // Use Math.max rather than addition: the deficit already accounts for
       // all external demand (including target rates from Phase 1), so adding
       // would double-count any pre-existing demand in itemDemands.
-      itemDemands.set(
-        itemId,
-        Math.max(itemDemands.get(itemId) || 0, deficit),
-      );
+      itemDemands.set(itemId, Math.max(itemDemands.get(itemId) || 0, deficit));
       console.log(
         `  Item ${itemId} has deficit of ${deficit.toFixed(4)}/min — propagated to external producers`,
       );
@@ -977,8 +1005,7 @@ function tryExtendSCCWithFeeders(
           const recipe = maps.recipeMap.get(rid)!;
           const input = recipe.inputs.find((i) => i.itemId === itemId);
           if (input) {
-            overrideDemand +=
-              calcRate(input.amount, recipe.craftingTime) * fc;
+            overrideDemand += calcRate(input.amount, recipe.craftingTime) * fc;
           }
         }
       });
@@ -1174,12 +1201,7 @@ function tryExtendSCCWithFeeders(
   );
   const freeM = freeIndices.length;
 
-  console.log(
-    `  [SCC_EXTEND] Solving extended system: ${n} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${m} total)`,
-  );
-
-  const matrix: number[][] = [];
-  const constants: number[] = [];
+  const extRawRows: SystemRow[] = [];
 
   for (let i = 0; i < n; i++) {
     const itemId = extItemsList[i];
@@ -1204,35 +1226,19 @@ function tryExtendSCCWithFeeders(
       }
     }
 
-    matrix.push(row);
-    constants.push(rhs);
+    extRawRows.push({ row, rhs, itemId });
   }
 
-  // Solve the reduced system
-  let freeSolution: number[] | null;
-  if (freeM === 0) {
-    freeSolution = [];
-  } else if (n > freeM) {
-    // Overdetermined after pinning
-    if (freeM === 1) {
-      let maxR = 0;
-      for (let i = 0; i < n; i++) {
-        const a = matrix[i][0];
-        const b = constants[i];
-        if (Math.abs(a) > 1e-9) {
-          const r = b / a;
-          if (r > maxR) maxR = r;
-        }
-      }
-      freeSolution = [maxR];
-    } else {
-      const subMatrix = matrix.slice(0, freeM);
-      const subConstants = constants.slice(0, freeM);
-      freeSolution = solveLinearSystem(subMatrix, subConstants);
-    }
-  } else {
-    freeSolution = solveLinearSystem(matrix, constants);
-  }
+  const extFilteredRows = filterImpossibleDisposalRows(extRawRows);
+  const matrix = extFilteredRows.map((e) => e.row);
+  const constants = extFilteredRows.map((e) => e.rhs);
+  const extEffectiveN = extFilteredRows.length;
+
+  console.log(
+    `  [SCC_EXTEND] Solving extended system: ${extEffectiveN} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${m} total)`,
+  );
+
+  const freeSolution = solveOverdetermined(matrix, constants, freeM);
 
   if (!freeSolution) {
     console.warn(
@@ -1280,10 +1286,7 @@ function tryExtendSCCWithFeeders(
     const deficit = externalDemand - netProduction;
 
     if (deficit > 1e-9) {
-      itemDemands.set(
-        itemId,
-        Math.max(itemDemands.get(itemId) || 0, deficit),
-      );
+      itemDemands.set(itemId, Math.max(itemDemands.get(itemId) || 0, deficit));
       console.log(
         `  [SCC_EXTEND] Item ${itemId} has deficit of ${deficit.toFixed(4)}/min — propagated`,
       );
@@ -1377,8 +1380,7 @@ function injectDisposalRecipes(
     graph.recipeOutputs.forEach((outputItems, recipeId) => {
       if (outputItems.has(itemId)) {
         const recipe = maps.recipeMap.get(recipeId)!;
-        const facilityCount =
-          flowData.recipeFacilityCounts.get(recipeId) || 0;
+        const facilityCount = flowData.recipeFacilityCounts.get(recipeId) || 0;
         const output = recipe.outputs.find((o) => o.itemId === itemId);
         if (output) {
           totalProduction +=
@@ -1395,8 +1397,7 @@ function injectDisposalRecipes(
         const recipe = maps.recipeMap.get(recipeId)!;
         // Skip disposal recipes to avoid double-counting
         if (recipe.outputs.length === 0) continue;
-        const facilityCount =
-          flowData.recipeFacilityCounts.get(recipeId) || 0;
+        const facilityCount = flowData.recipeFacilityCounts.get(recipeId) || 0;
         const input = recipe.inputs.find((i) => i.itemId === itemId);
         if (input) {
           totalConsumption +=
@@ -1406,8 +1407,7 @@ function injectDisposalRecipes(
     }
 
     // Subtract target demand (user wants to collect this amount, not dispose)
-    const targetDemand =
-      targets.find((t) => t.itemId === itemId)?.rate || 0;
+    const targetDemand = targets.find((t) => t.itemId === itemId)?.rate || 0;
 
     const surplus = totalProduction - totalConsumption - targetDemand;
     if (surplus <= 0) continue;
@@ -1415,8 +1415,7 @@ function injectDisposalRecipes(
     // Find the matching disposal recipe
     const disposalRecipe = Array.from(maps.recipeMap.values()).find(
       (r) =>
-        r.outputs.length === 0 &&
-        r.inputs.some((i) => i.itemId === itemId),
+        r.outputs.length === 0 && r.inputs.some((i) => i.itemId === itemId),
     );
     if (!disposalRecipe) continue;
 
@@ -1453,10 +1452,7 @@ function injectDisposalRecipes(
     graph.itemConsumedBy.get(itemId)!.add(disposalRecipe.id);
 
     // Record facility count in flow data
-    flowData.recipeFacilityCounts.set(
-      disposalRecipe.id,
-      disposalFacilityCount,
-    );
+    flowData.recipeFacilityCounts.set(disposalRecipe.id, disposalFacilityCount);
   }
 }
 
@@ -1532,9 +1528,7 @@ function buildProductionGraph(
 
   // Build cycle info — exclude SCCs that were resolved by feeder extension
   // since they are now linear chains, not true production cycles.
-  const activeSCCs = sccs.filter(
-    (scc) => !flowData.resolvedSCCIds.has(scc.id),
-  );
+  const activeSCCs = sccs.filter((scc) => !flowData.resolvedSCCIds.has(scc.id));
   const detectedCycles: DetectedCycle[] = activeSCCs.map((scc) => {
     const cycleNodes: ProductionNode[] = Array.from(scc.recipes).flatMap(
       (recipeId) => {

--- a/src/lib/linear-solver.ts
+++ b/src/lib/linear-solver.ts
@@ -65,3 +65,45 @@ export function solveLinearSystem(
 
   return x;
 }
+
+/**
+ * Solve an over/exactly-determined linear system.
+ * - `numVars === 0` → returns `[]` (no unknowns).
+ * - `rows.length > numVars` (overdetermined):
+ *   - `numVars === 1`: return `[max(b/a)]` across rows with non-zero coefficient,
+ *     matching the Phase 4 deficit-propagation semantics (satisfy tightest constraint).
+ *   - Otherwise pick the `numVars` rows with largest |RHS| and solve that square system.
+ * - `rows.length <= numVars`: solve directly via `solveLinearSystem`.
+ * Returns `null` on singular systems.
+ */
+export function solveOverdetermined(
+  matrix: number[][],
+  constants: number[],
+  numVars: number,
+): number[] | null {
+  if (numVars === 0) return [];
+  const rowCount = matrix.length;
+
+  if (rowCount > numVars) {
+    if (numVars === 1) {
+      let maxR = 0;
+      for (let i = 0; i < rowCount; i++) {
+        const a = matrix[i][0];
+        const b = constants[i];
+        if (Math.abs(a) > 1e-9) {
+          const r = b / a;
+          if (r > maxR) maxR = r;
+        }
+      }
+      return [maxR];
+    }
+    const indices = Array.from({ length: rowCount }, (_, i) => i);
+    indices.sort((a, b) => Math.abs(constants[b]) - Math.abs(constants[a]));
+    const topIndices = indices.slice(0, numVars);
+    const subMatrix = topIndices.map((i) => matrix[i]);
+    const subConstants = topIndices.map((i) => constants[i]);
+    return solveLinearSystem(subMatrix, subConstants);
+  }
+
+  return solveLinearSystem(matrix, constants);
+}

--- a/src/tests/lib/calculator.test.ts
+++ b/src/tests/lib/calculator.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
 import { calculateProductionPlan } from "@/lib/calculator";
+import { items } from "@/data/items";
+import { recipes } from "@/data/recipes";
+import { facilities } from "@/data/facilities";
 import type {
   ProductionDependencyGraph,
   ProductionGraphNode,
@@ -1037,5 +1040,36 @@ describe("Xircon Production Chain", () => {
     const sewageDisposalId =
       RecipeId.FLUID_CONSUME_LIQUID_CLEANER_1_ITEM_LIQUID_SEWAGE;
     expect(plan.nodes.has(sewageDisposalId)).toBe(false);
+  });
+});
+
+describe("Real 1.2 data regression", () => {
+  test("xiranite_enr_powder produces complete chain with no invalid cycles", () => {
+    const plan = calculateProductionPlan(
+      [{ itemId: ItemId.ITEM_XIRANITE_ENR_POWDER, rate: 6 }],
+      items,
+      recipes,
+      facilities,
+    );
+    expect(plan.invalidCycles).toEqual([]);
+
+    const target = plan.nodes.get(ItemId.ITEM_XIRANITE_ENR_POWDER);
+    expect(target?.type).toBe("item");
+    if (target?.type === "item") {
+      expect(target.productionRate).toBeGreaterThanOrEqual(6);
+    }
+
+    const powderRecipe = plan.nodes.get(RecipeId.XIRANITE_OVEN_XIRANITE_POWDER_1);
+    expect(powderRecipe?.type).toBe("recipe");
+    if (powderRecipe?.type === "recipe") {
+      expect(powderRecipe.facilityCount).toBeGreaterThan(0);
+    }
+
+    const mossGrinder = plan.nodes.get(RecipeId.GRINDER_PLANT_MOSS_POWDER_1_1);
+    expect(mossGrinder).toBeDefined();
+    expect(mossGrinder?.type).toBe("recipe");
+    if (mossGrinder?.type === "recipe") {
+      expect(mossGrinder.facilityCount).toBeGreaterThan(0);
+    }
   });
 });


### PR DESCRIPTION
- **`filterImpossibleDisposalRows`** (`calculator.ts`) — drops rows where a forced-disposal item has an all-zero LHS and       
  non-zero RHS. These equations are unsatisfiable in the linear system, but the surplus they represent is absorbed later by   `injectDisposalRecipes`, so they must not force the solver into a "no solution" return.  
                                                