### PR TITLE
Fix: SCC solver treats disposal-item surplus as infeasible constraint

### DIFF
--- a/src/lib/calculator-types.ts
+++ b/src/lib/calculator-types.ts
@@ -1,0 +1,70 @@
+import type { ItemId, RecipeId, FacilityId, Item, Recipe, Facility } from "@/types";
+
+export type SystemRow = { row: number[]; rhs: number; itemId: ItemId };
+
+export type ProductionMaps = {
+  itemMap: Map<ItemId, Item>;
+  recipeMap: Map<RecipeId, Recipe>;
+  facilityMap: Map<FacilityId, Facility>;
+};
+
+export type ItemNode = {
+  itemId: ItemId;
+  item: Item;
+  isRawMaterial: boolean;
+};
+
+export type RecipeNodeData = {
+  recipeId: RecipeId;
+  recipe: Recipe;
+  facility: Facility;
+};
+
+export type BipartiteGraph = {
+  itemNodes: Map<ItemId, ItemNode>;
+  recipeNodes: Map<RecipeId, RecipeNodeData>;
+
+  itemConsumedBy: Map<ItemId, Set<RecipeId>>;
+
+  recipeInputs: Map<RecipeId, Set<ItemId>>;
+  recipeOutputs: Map<RecipeId, Set<ItemId>>;
+
+  targets: Set<ItemId>;
+  rawMaterials: Set<ItemId>;
+};
+
+export type SCCInfo = {
+  id: string;
+  items: Set<ItemId>;
+  recipes: Set<RecipeId>;
+  externalInputs: Set<ItemId>;
+};
+
+export type CondensedNode =
+  | { type: "item"; itemId: ItemId }
+  | { type: "recipe"; recipeId: RecipeId }
+  | { type: "scc"; scc: SCCInfo };
+
+export type FlowData = {
+  itemDemands: Map<ItemId, number>;
+  recipeFacilityCounts: Map<RecipeId, number>;
+  /** SCC IDs that were resolved by feeder extension (no longer true cycles) */
+  resolvedSCCIds: Set<string>;
+};
+
+export type RecipeChoice = {
+  itemId: ItemId;
+  availableRecipes: RecipeId[];
+  currentIndex: number;
+};
+
+export type BuildGraphResult = {
+  graph: BipartiteGraph;
+  recipeChoices: Map<ItemId, RecipeChoice>;
+};
+
+export type InvalidSCCInfo = {
+  sccId: string;
+  involvedItems: Set<ItemId>;
+  reason: "no_solution" | "no_external_demand";
+};

--- a/src/lib/calculator.ts
+++ b/src/lib/calculator.ts
@@ -4,1426 +4,25 @@ import type {
   Facility,
   ItemId,
   RecipeId,
-  FacilityId,
   ProductionNode,
   DetectedCycle,
   InvalidCycleInfo,
   ProductionDependencyGraph,
   ProductionGraphNode,
 } from "@/types";
-import { solveOverdetermined } from "./linear-solver";
-import { forcedRawMaterials, forcedDisposalItems } from "@/data";
+import { forcedDisposalItems } from "@/data";
 import { calcRate } from "@/lib/utils";
+import { buildBipartiteGraph, detectSCCs, buildCondensedDAGAndSort } from "./graph-builder";
+import { calculateFlows } from "./flow-solver";
+import type {
+  ProductionMaps,
+  BipartiteGraph,
+  SCCInfo,
+  FlowData,
+  RecipeChoice,
+  InvalidSCCInfo,
+} from "./calculator-types";
 
-type SystemRow = { row: number[]; rhs: number; itemId: ItemId };
-
-const isAllZeroRow = (row: number[]): boolean =>
-  row.every((v) => Math.abs(v) < 1e-9);
-
-// Drops equations the SCC solver must not enforce:
-//   1. Unsatisfiable: forced-disposal item with zero LHS and non-zero RHS —
-//      surplus is handled later by injectDisposalRecipes.
-//   2. Slack: forced-disposal-surplus (rhs <= 0) or forced-raw-supply items,
-//      dropped greedily while keeping at least numVars rows so the system
-//      stays determined. Raw-material rows go first (deficit always absorbed
-//      by external supply); disposal rows may still carry balance info.
-const filterImpossibleDisposalRows = (
-  rows: SystemRow[],
-  numVars: number,
-  rawMaterials: Set<ItemId>,
-): SystemRow[] => {
-  const base = rows.filter(
-    ({ row, rhs, itemId }) =>
-      !forcedDisposalItems.has(itemId) ||
-      !isAllZeroRow(row) ||
-      Math.abs(rhs) < 1e-9,
-  );
-  const isRawSlack = (r: SystemRow) => rawMaterials.has(r.itemId);
-  const isDisposalSlack = (r: SystemRow) =>
-    forcedDisposalItems.has(r.itemId) && r.rhs <= 1e-9;
-  const remaining = base.slice();
-  for (const isSlack of [isRawSlack, isDisposalSlack]) {
-    for (let i = remaining.length - 1; i >= 0; i--) {
-      if (remaining.length <= numVars) break;
-      if (isSlack(remaining[i])) remaining.splice(i, 1);
-    }
-  }
-  return remaining;
-};
-
-// Dismantler recipes consume fbottle_* items (bottled products) as inputs.
-// They are reverse/recovery recipes and should be deprioritized during auto-selection
-// to avoid creating spurious bottle ↔ fbottle ↔ liquid cycles in the dependency graph.
-const isDismantleRecipe = (r: Recipe): boolean =>
-  r.inputs.some((i) => i.itemId.startsWith("item_fbottle_"));
-
-const selectRecipe = (recipes: Recipe[], visitedPath: Set<ItemId>): Recipe => {
-  // Prefer synthesis recipes over dismantle/recovery recipes.
-  // Fall back to full candidate list only if all recipes are dismantle type.
-  const nonDismantle = recipes.filter((r) => !isDismantleRecipe(r));
-  const pool = nonDismantle.length > 0 ? nonDismantle : recipes;
-
-  // Priority 1: Recipes with single output (no byproducts)
-  const singleOutput = pool.filter((r) => r.outputs.length === 1);
-
-  if (singleOutput.length > 0) {
-    // Priority 2: Among single-output recipes, prefer non-circular ones
-    if (visitedPath.size > 0) {
-      const nonCircular = singleOutput.filter(
-        (r) => !r.inputs.some((input) => visitedPath.has(input.itemId)),
-      );
-
-      if (nonCircular.length > 0) {
-        return nonCircular[0];
-      }
-    }
-
-    // Priority 3: Return first single-output recipe
-    return singleOutput[0];
-  }
-
-  // Priority 4: If no single-output recipes, prefer non-circular
-  if (visitedPath.size > 0) {
-    const nonCircular = pool.filter(
-      (r) => !r.inputs.some((input) => visitedPath.has(input.itemId)),
-    );
-
-    if (nonCircular.length > 0) {
-      return nonCircular[0];
-    }
-  }
-
-  // Priority 5: Default to first available recipe
-  return pool[0];
-};
-
-type ProductionMaps = {
-  itemMap: Map<ItemId, Item>;
-  recipeMap: Map<RecipeId, Recipe>;
-  facilityMap: Map<FacilityId, Facility>;
-};
-
-type ItemNode = {
-  itemId: ItemId;
-  item: Item;
-  isRawMaterial: boolean;
-};
-
-type RecipeNodeData = {
-  recipeId: RecipeId;
-  recipe: Recipe;
-  facility: Facility;
-};
-
-type BipartiteGraph = {
-  itemNodes: Map<ItemId, ItemNode>;
-  recipeNodes: Map<RecipeId, RecipeNodeData>;
-
-  itemConsumedBy: Map<ItemId, Set<RecipeId>>;
-
-  recipeInputs: Map<RecipeId, Set<ItemId>>;
-  recipeOutputs: Map<RecipeId, Set<ItemId>>;
-
-  targets: Set<ItemId>;
-  rawMaterials: Set<ItemId>;
-};
-type SCCInfo = {
-  id: string;
-  items: Set<ItemId>;
-  recipes: Set<RecipeId>;
-  externalInputs: Set<ItemId>;
-};
-
-type CondensedNode =
-  | { type: "item"; itemId: ItemId }
-  | { type: "recipe"; recipeId: RecipeId }
-  | { type: "scc"; scc: SCCInfo };
-
-type FlowData = {
-  itemDemands: Map<ItemId, number>;
-  recipeFacilityCounts: Map<RecipeId, number>;
-  /** SCC IDs that were resolved by feeder extension (no longer true cycles) */
-  resolvedSCCIds: Set<string>;
-};
-
-type RecipeChoice = {
-  itemId: ItemId;
-  availableRecipes: RecipeId[];
-  currentIndex: number;
-};
-
-type BuildGraphResult = {
-  graph: BipartiteGraph;
-  recipeChoices: Map<ItemId, RecipeChoice>;
-};
-
-type InvalidSCCInfo = {
-  sccId: string;
-  involvedItems: Set<ItemId>;
-  reason: "no_solution" | "no_external_demand";
-};
-
-const getOrThrow = <K, V>(map: Map<K, V>, key: K, type: string): V => {
-  const value = map.get(key);
-  if (!value) throw new Error(`${type} not found: ${key}`);
-  return value;
-};
-
-function buildBipartiteGraph(
-  targets: Array<{ itemId: ItemId; rate: number }>,
-  maps: ProductionMaps,
-  recipeOverrides?: Map<ItemId, RecipeId>,
-  manualRawMaterials?: Set<ItemId>,
-  recipeConstraints?: Map<ItemId, Set<RecipeId>>, // New parameter: excluded recipes per item
-): BuildGraphResult {
-  const graph: BipartiteGraph = {
-    itemNodes: new Map(),
-    recipeNodes: new Map(),
-    itemConsumedBy: new Map(),
-    recipeInputs: new Map(),
-    recipeOutputs: new Map(),
-    targets: new Set(targets.map((t) => t.itemId)),
-    rawMaterials: new Set(),
-  };
-
-  const recipeChoices = new Map<ItemId, RecipeChoice>();
-  const visitedItems = new Set<ItemId>();
-
-  function traverse(itemId: ItemId, visitedPath: Set<ItemId>) {
-    if (visitedItems.has(itemId)) return;
-    visitedItems.add(itemId);
-
-    const item = getOrThrow(maps.itemMap, itemId, "Item");
-
-    const isRaw =
-      forcedRawMaterials.has(itemId) ||
-      (manualRawMaterials?.has(itemId) ?? false);
-
-    graph.itemNodes.set(itemId, {
-      itemId,
-      item,
-      isRawMaterial: isRaw,
-    });
-
-    if (isRaw) {
-      graph.rawMaterials.add(itemId);
-      return;
-    }
-
-    let availableRecipes = Array.from(maps.recipeMap.values()).filter((r) =>
-      r.outputs.some((o) => o.itemId === itemId),
-    );
-
-    // Filter out excluded recipes
-    const excludedRecipes = recipeConstraints?.get(itemId);
-    if (excludedRecipes && excludedRecipes.size > 0) {
-      availableRecipes = availableRecipes.filter(
-        (r) => !excludedRecipes.has(r.id),
-      );
-    }
-
-    if (availableRecipes.length === 0) {
-      graph.itemNodes.get(itemId)!.isRawMaterial = true;
-      graph.rawMaterials.add(itemId);
-      return;
-    }
-
-    // Record recipe choices for this item
-    const recipeIds = availableRecipes.map((r) => r.id);
-    let currentIndex = 0;
-
-    // Determine which recipe to use
-    let selectedRecipe: Recipe;
-    if (recipeOverrides?.has(itemId)) {
-      selectedRecipe = getOrThrow(
-        maps.recipeMap,
-        recipeOverrides.get(itemId)!,
-        "Override recipe",
-      );
-      currentIndex = recipeIds.indexOf(selectedRecipe.id);
-      if (currentIndex === -1) currentIndex = 0;
-    } else {
-      selectedRecipe = selectRecipe(availableRecipes, visitedPath);
-      currentIndex = recipeIds.indexOf(selectedRecipe.id);
-    }
-
-    // Store choice information only if there are multiple options
-    if (availableRecipes.length > 1) {
-      recipeChoices.set(itemId, {
-        itemId,
-        availableRecipes: recipeIds,
-        currentIndex,
-      });
-    }
-
-    const facility = getOrThrow(
-      maps.facilityMap,
-      selectedRecipe.facilityId,
-      "Facility",
-    );
-
-    if (!graph.recipeNodes.has(selectedRecipe.id)) {
-      graph.recipeNodes.set(selectedRecipe.id, {
-        recipeId: selectedRecipe.id,
-        recipe: selectedRecipe,
-        facility,
-      });
-
-      graph.recipeInputs.set(selectedRecipe.id, new Set());
-      graph.recipeOutputs.set(selectedRecipe.id, new Set());
-    }
-
-    selectedRecipe.outputs.forEach((out) => {
-      graph.recipeOutputs.get(selectedRecipe.id)!.add(out.itemId);
-
-      // Ensure byproduct items exist in the graph as produced (non-raw) nodes.
-      // Byproducts are NOT marked as visited so that if they are later consumed
-      // by another recipe, the traverse can discover an external production recipe
-      // for them. This is essential for cycles with net deficits (e.g., liquid_sewage
-      // in the Xircon chain needs an external source via furnace).
-      if (!graph.itemNodes.has(out.itemId)) {
-        const outItem = maps.itemMap.get(out.itemId);
-        if (outItem) {
-          graph.itemNodes.set(out.itemId, {
-            itemId: out.itemId,
-            item: outItem,
-            isRawMaterial: false,
-          });
-        }
-      }
-    });
-
-    const newVisitedPath = new Set(visitedPath);
-    newVisitedPath.add(itemId);
-
-    selectedRecipe.inputs.forEach((input) => {
-      graph.recipeInputs.get(selectedRecipe.id)!.add(input.itemId);
-
-      if (!graph.itemConsumedBy.has(input.itemId)) {
-        graph.itemConsumedBy.set(input.itemId, new Set());
-      }
-      graph.itemConsumedBy.get(input.itemId)!.add(selectedRecipe.id);
-
-      traverse(input.itemId, newVisitedPath);
-    });
-  }
-
-  targets.forEach(({ itemId }) => traverse(itemId, new Set()));
-
-  return { graph, recipeChoices };
-}
-
-function detectSCCs(graph: BipartiteGraph): SCCInfo[] {
-  const sccs: SCCInfo[] = [];
-  const indices = new Map<string, number>();
-  const lowlinks = new Map<string, number>();
-  const onStack = new Set<string>();
-  const stack: string[] = [];
-  let index = 0;
-
-  function strongConnect(nodeId: string, nodeType: "item" | "recipe") {
-    indices.set(nodeId, index);
-    lowlinks.set(nodeId, index);
-    index++;
-    stack.push(nodeId);
-    onStack.add(nodeId);
-
-    const successors: Array<[string, "item" | "recipe"]> = [];
-
-    if (nodeType === "item") {
-      const consumerRecipes = graph.itemConsumedBy.get(nodeId as ItemId);
-      if (consumerRecipes) {
-        consumerRecipes.forEach((recipeId) => {
-          successors.push([recipeId, "recipe"]);
-        });
-      }
-    } else {
-      const outputs = graph.recipeOutputs.get(nodeId as RecipeId);
-      if (outputs) {
-        outputs.forEach((itemId) => {
-          successors.push([itemId, "item"]);
-        });
-      }
-    }
-
-    successors.forEach(([succId, succType]) => {
-      if (!indices.has(succId)) {
-        strongConnect(succId, succType);
-        lowlinks.set(
-          nodeId,
-          Math.min(lowlinks.get(nodeId)!, lowlinks.get(succId)!),
-        );
-      } else if (onStack.has(succId)) {
-        lowlinks.set(
-          nodeId,
-          Math.min(lowlinks.get(nodeId)!, indices.get(succId)!),
-        );
-      }
-    });
-
-    if (lowlinks.get(nodeId) === indices.get(nodeId)) {
-      const sccItems = new Set<ItemId>();
-      const sccRecipes = new Set<RecipeId>();
-
-      let w: string;
-      do {
-        w = stack.pop()!;
-        onStack.delete(w);
-
-        if (graph.itemNodes.has(w as ItemId)) {
-          sccItems.add(w as ItemId);
-        } else {
-          sccRecipes.add(w as RecipeId);
-        }
-      } while (w !== nodeId);
-
-      if (sccItems.size + sccRecipes.size > 1) {
-        const externalInputs = new Set<ItemId>();
-
-        sccRecipes.forEach((recipeId) => {
-          const inputs = graph.recipeInputs.get(recipeId) || new Set();
-          inputs.forEach((inputItemId) => {
-            if (!sccItems.has(inputItemId)) {
-              externalInputs.add(inputItemId);
-            }
-          });
-        });
-
-        const sccInfo: SCCInfo = {
-          id: `scc-${Array.from(sccItems).sort().join("-")}`,
-          items: sccItems,
-          recipes: sccRecipes,
-          externalInputs,
-        };
-
-        // LOG: SCC detected
-        console.log(`[SCC] Detected cycle: ${sccInfo.id}`);
-        console.log(`  Items (${sccItems.size}):`, Array.from(sccItems));
-        console.log(`  Recipes (${sccRecipes.size}):`, Array.from(sccRecipes));
-        console.log(
-          `  External inputs (${externalInputs.size}):`,
-          Array.from(externalInputs),
-        );
-
-        sccs.push(sccInfo);
-      }
-    }
-  }
-
-  graph.itemNodes.forEach((_, itemId) => {
-    if (!indices.has(itemId)) {
-      strongConnect(itemId, "item");
-    }
-  });
-
-  console.log(`[SCC] Total SCCs detected: ${sccs.length}`);
-  return sccs;
-}
-
-function buildCondensedDAGAndSort(
-  graph: BipartiteGraph,
-  sccs: SCCInfo[],
-): CondensedNode[] {
-  const nodeToSCC = new Map<string, string>();
-
-  sccs.forEach((scc) => {
-    scc.items.forEach((itemId) => nodeToSCC.set(itemId, scc.id));
-    scc.recipes.forEach((recipeId) => nodeToSCC.set(recipeId, scc.id));
-  });
-
-  const condensedNodes = new Map<string, CondensedNode>();
-  const condensedEdges = new Map<string, Set<string>>();
-
-  sccs.forEach((scc) => {
-    condensedNodes.set(scc.id, { type: "scc", scc });
-    condensedEdges.set(scc.id, new Set());
-  });
-
-  graph.itemNodes.forEach((_, itemId) => {
-    if (!nodeToSCC.has(itemId)) {
-      condensedNodes.set(itemId, { type: "item", itemId });
-      condensedEdges.set(itemId, new Set());
-    }
-  });
-
-  graph.recipeNodes.forEach((_, recipeId) => {
-    if (!nodeToSCC.has(recipeId)) {
-      condensedNodes.set(recipeId, { type: "recipe", recipeId });
-      condensedEdges.set(recipeId, new Set());
-    }
-  });
-
-  const addEdge = (fromId: string, toId: string) => {
-    const fromCondensed = nodeToSCC.get(fromId) || fromId;
-    const toCondensed = nodeToSCC.get(toId) || toId;
-
-    if (fromCondensed !== toCondensed) {
-      condensedEdges.get(fromCondensed)!.add(toCondensed);
-    }
-  };
-
-  graph.itemConsumedBy.forEach((recipeIds, itemId) => {
-    recipeIds.forEach((recipeId) => {
-      addEdge(itemId, recipeId);
-    });
-  });
-
-  graph.recipeOutputs.forEach((itemIds, recipeId) => {
-    itemIds.forEach((itemId) => {
-      addEdge(recipeId, itemId);
-    });
-  });
-
-  const inDegree = new Map<string, number>();
-  condensedNodes.forEach((_, nodeId) => {
-    inDegree.set(nodeId, 0);
-  });
-
-  condensedEdges.forEach((targets) => {
-    targets.forEach((target) => {
-      inDegree.set(target, (inDegree.get(target) || 0) + 1);
-    });
-  });
-
-  const queue: string[] = [];
-  inDegree.forEach((degree, nodeId) => {
-    if (degree === 0) queue.push(nodeId);
-  });
-
-  const topoOrder: CondensedNode[] = [];
-
-  while (queue.length > 0) {
-    const nodeId = queue.shift()!;
-    topoOrder.push(condensedNodes.get(nodeId)!);
-
-    condensedEdges.get(nodeId)!.forEach((target) => {
-      const newDegree = inDegree.get(target)! - 1;
-      inDegree.set(target, newDegree);
-      if (newDegree === 0) {
-        queue.push(target);
-      }
-    });
-  }
-
-  return topoOrder;
-}
-
-function calculateFlows(
-  graph: BipartiteGraph,
-  condensedOrder: CondensedNode[],
-  targetRates: Map<ItemId, number>,
-  maps: ProductionMaps,
-  recipeOverrides?: Map<ItemId, RecipeId>,
-  manualRawMaterials?: Set<ItemId>,
-): { flowData: FlowData; invalidSCCs: InvalidSCCInfo[] } {
-  const itemDemands = new Map<ItemId, number>();
-  const recipeFacilityCounts = new Map<RecipeId, number>();
-  const resolvedSCCIds = new Set<string>();
-  const invalidSCCs: InvalidSCCInfo[] = [];
-
-  targetRates.forEach((rate, itemId) => {
-    itemDemands.set(itemId, rate);
-  });
-
-  const reversedOrder = [...condensedOrder].reverse();
-
-  console.log(
-    `[FLOW] Processing ${reversedOrder.length} condensed nodes in topological order`,
-  );
-
-  reversedOrder.forEach((node, idx) => {
-    if (node.type === "scc") {
-      console.log(`[FLOW] [${idx}] Processing SCC: ${node.scc.id}`);
-      const solved = solveSCCFlow(
-        node.scc,
-        graph,
-        itemDemands,
-        recipeFacilityCounts,
-        maps,
-        recipeOverrides,
-        resolvedSCCIds,
-        manualRawMaterials,
-      );
-
-      if (!solved) {
-        // Record invalid SCC
-        const reason =
-          node.scc.externalInputs.size === 0
-            ? "no_external_demand"
-            : "no_solution";
-        invalidSCCs.push({
-          sccId: node.scc.id,
-          involvedItems: node.scc.items,
-          reason,
-        });
-        console.log(
-          `  [FLOW] Recorded invalid SCC: ${node.scc.id} (${reason})`,
-        );
-      }
-    } else if (node.type === "recipe") {
-      console.log(`[FLOW] [${idx}] Processing recipe: ${node.recipeId}`);
-      const recipeData = graph.recipeNodes.get(node.recipeId)!;
-      const recipe = recipeData.recipe;
-
-      const outputs = graph.recipeOutputs.get(node.recipeId)!;
-
-      let facilityCount = 0;
-
-      outputs.forEach((itemId) => {
-        const demand = itemDemands.get(itemId) || 0;
-        const output = recipe.outputs.find((o) => o.itemId === itemId);
-        if (!output) return;
-
-        const rate = calcRate(output.amount, recipe.craftingTime);
-        if (rate > 0) {
-          facilityCount = Math.max(facilityCount, demand / rate);
-        }
-      });
-
-      recipeFacilityCounts.set(node.recipeId, facilityCount);
-      console.log(`  Facility count: ${facilityCount.toFixed(4)}`);
-
-      recipe.inputs.forEach((input) => {
-        const inputDemand =
-          calcRate(input.amount, recipe.craftingTime) * facilityCount;
-        itemDemands.set(
-          input.itemId,
-          (itemDemands.get(input.itemId) || 0) + inputDemand,
-        );
-      });
-    } else if (node.type === "item") {
-      console.log(`[FLOW] [${idx}] Processing item: ${node.itemId}`);
-    }
-  });
-
-  return {
-    flowData: { itemDemands, recipeFacilityCounts, resolvedSCCIds },
-    invalidSCCs,
-  };
-}
-
-function solveSCCFlow(
-  scc: SCCInfo,
-  graph: BipartiteGraph,
-  itemDemands: Map<ItemId, number>,
-  recipeFacilityCounts: Map<RecipeId, number>,
-  maps: ProductionMaps,
-  recipeOverrides?: Map<ItemId, RecipeId>,
-  resolvedSCCIds?: Set<string>,
-  manualRawMaterials?: Set<ItemId>,
-): boolean {
-  console.log(`[SCC_SOLVE] Solving flow for SCC: ${scc.id}`);
-
-  const recipesList = Array.from(scc.recipes).map(
-    (rid) => maps.recipeMap.get(rid)!,
-  );
-  const itemsList = Array.from(scc.items);
-  const n = itemsList.length;
-  const m = recipesList.length;
-
-  if (m === 0 || n === 0) {
-    console.log(`  [SCC_SOLVE] Empty system, skipping`);
-    return false;
-  }
-
-  // --- Phase 1: Compute external demands for SCC-internal items ---
-  const externalDemands = new Map<ItemId, number>();
-
-  scc.items.forEach((itemId) => {
-    let demand = 0;
-
-    // Demand from recipes outside the SCC
-    const consumers = graph.itemConsumedBy.get(itemId);
-    if (consumers) {
-      consumers.forEach((recipeId) => {
-        if (!scc.recipes.has(recipeId)) {
-          const facilityCount = recipeFacilityCounts.get(recipeId) || 0;
-          const recipe = maps.recipeMap.get(recipeId)!;
-          const input = recipe.inputs.find((i) => i.itemId === itemId);
-          if (input) {
-            const consumption =
-              calcRate(input.amount, recipe.craftingTime) * facilityCount;
-            demand += consumption;
-            console.log(
-              `    Item ${itemId} consumed by external recipe ${recipeId}: ${consumption.toFixed(4)}`,
-            );
-          }
-        }
-      });
-    }
-
-    // Demand from target items
-    if (graph.targets.has(itemId)) {
-      const targetDemand = itemDemands.get(itemId) || 0;
-      demand += targetDemand;
-      console.log(
-        `    Item ${itemId} is target with demand: ${targetDemand.toFixed(4)}`,
-      );
-    }
-
-    if (demand > 0) {
-      externalDemands.set(itemId, demand);
-    }
-  });
-
-  // --- Phase 2: Compute external output demands ---
-  // Items OUTSIDE the SCC that are produced by SCC recipes and have demand.
-  // Group by external item so multi-producer cases can share a single
-  // constraint (sum rate_j * r_j = demand) rather than pinning each recipe
-  // independently to demand/rate (which would overdetermine the system with
-  // total output = k × demand).
-  const externalOutputByItem = new Map<
-    ItemId,
-    { demand: number; producers: { recipeIdx: number; rate: number }[] }
-  >();
-
-  for (let j = 0; j < m; j++) {
-    const recipe = recipesList[j];
-
-    for (const out of recipe.outputs) {
-      if (scc.items.has(out.itemId)) continue; // Skip SCC-internal items
-
-      const demand = itemDemands.get(out.itemId) || 0;
-      if (demand <= 0) continue;
-
-      const rate = calcRate(out.amount, recipe.craftingTime);
-      if (rate <= 0) continue;
-
-      let entry = externalOutputByItem.get(out.itemId);
-      if (!entry) {
-        entry = { demand, producers: [] };
-        externalOutputByItem.set(out.itemId, entry);
-      }
-      entry.producers.push({ recipeIdx: j, rate });
-      console.log(
-        `    Recipe ${recipe.id} produces external item ${out.itemId} with demand: ${demand.toFixed(4)}/min (rate: ${rate.toFixed(4)}/facility)`,
-      );
-    }
-  }
-
-  const hasExternalOutputDemand = externalOutputByItem.size > 0;
-
-  // Early exit if no demand at all (neither internal nor external output)
-  if (externalDemands.size === 0 && !hasExternalOutputDemand) {
-    console.log(`  [SCC_SOLVE] No external demand, this is an invalid cycle`);
-    // Try feeder extension before giving up
-    return tryExtendSCCWithFeeders(
-      scc,
-      graph,
-      itemDemands,
-      recipeFacilityCounts,
-      maps,
-      recipeOverrides,
-      resolvedSCCIds,
-      manualRawMaterials,
-    );
-  }
-
-  console.log(
-    `  External demands (internal items): ${externalDemands.size}, External output items: ${externalOutputByItem.size}`,
-  );
-
-  // --- Phase 3: Solve with pinned facility counts ---
-  // Single-producer external items → pin that recipe to demand/rate.
-  // Multi-producer external items → leave recipes free, add a shared
-  // constraint row (sum rate_j * r_j = demand) so the solver distributes
-  // demand across producers.
-  const pinnedRecipes = new Map<number, number>(); // recipe index → facility count
-  const sharedOutputConstraints: { itemId: ItemId; demand: number }[] = [];
-
-  externalOutputByItem.forEach(({ demand, producers }, itemId) => {
-    if (producers.length === 1) {
-      const { recipeIdx, rate } = producers[0];
-      const pinnedCount = demand / rate;
-      const prev = pinnedRecipes.get(recipeIdx) ?? 0;
-      pinnedRecipes.set(recipeIdx, Math.max(prev, pinnedCount));
-      console.log(
-        `  Pinning recipe ${recipesList[recipeIdx].id} (index ${recipeIdx}) to ${pinnedCount.toFixed(4)} facilities (single producer of ${itemId})`,
-      );
-    } else {
-      sharedOutputConstraints.push({ itemId, demand });
-      console.log(
-        `  Shared constraint: ${producers.length} producers of external ${itemId} (total demand ${demand.toFixed(4)}/min)`,
-      );
-    }
-  });
-
-  if (pinnedRecipes.size > 0 || sharedOutputConstraints.length > 0) {
-    // Build reduced system: substitute pinned values, solve for remaining recipes
-    const freeIndices = Array.from({ length: m }, (_, i) => i).filter(
-      (i) => !pinnedRecipes.has(i),
-    );
-    const freeM = freeIndices.length;
-
-    const rawRows: SystemRow[] = [];
-
-    for (let i = 0; i < n; i++) {
-      const itemId = itemsList[i];
-      const row = new Array(freeM).fill(0);
-      const externalDemand = externalDemands.get(itemId) || 0;
-      let rhs = externalDemand;
-
-      for (let j = 0; j < m; j++) {
-        const recipe = recipesList[j];
-        const output =
-          recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
-        const input =
-          recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
-        const coeff =
-          calcRate(output, recipe.craftingTime) -
-          calcRate(input, recipe.craftingTime);
-
-        if (pinnedRecipes.has(j)) {
-          rhs -= coeff * pinnedRecipes.get(j)!;
-        } else {
-          const freeIdx = freeIndices.indexOf(j);
-          row[freeIdx] = coeff;
-        }
-      }
-
-      rawRows.push({ row, rhs, itemId });
-    }
-
-    // Shared constraint rows: sum(rate_j * r_j) = demand for each
-    // multi-producer external item.
-    for (const { itemId, demand } of sharedOutputConstraints) {
-      const row = new Array(freeM).fill(0);
-      const producers = externalOutputByItem.get(itemId)!.producers;
-      for (const { recipeIdx, rate } of producers) {
-        const freeIdx = freeIndices.indexOf(recipeIdx);
-        if (freeIdx >= 0) row[freeIdx] += rate;
-      }
-      rawRows.push({ row, rhs: demand, itemId });
-    }
-
-    const filteredRows = filterImpossibleDisposalRows(
-      rawRows,
-      freeM,
-      graph.rawMaterials,
-    );
-    const matrix = filteredRows.map((e) => e.row);
-    const constants = filteredRows.map((e) => e.rhs);
-    const effectiveN = filteredRows.length;
-
-    console.log(
-      `  Building reduced system: ${effectiveN} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${sharedOutputConstraints.length} shared-output constraints, ${n + sharedOutputConstraints.length - effectiveN} disposal rows filtered)`,
-    );
-    filteredRows.forEach(({ row, rhs, itemId }, i) => {
-      console.log(
-        `    Equation ${i} (${itemId}):`,
-        row.map((v, fi) => `${v.toFixed(2)}*r${freeIndices[fi]}`).join(" + "),
-        `= ${rhs.toFixed(4)}`,
-      );
-    });
-
-    const freeSolution = solveOverdetermined(matrix, constants, freeM);
-
-    if (!freeSolution) {
-      console.warn(
-        `  [SCC_SOLVE] Cannot solve reduced SCC ${scc.id} - system has no solution`,
-      );
-      return tryExtendSCCWithFeeders(
-        scc,
-        graph,
-        itemDemands,
-        recipeFacilityCounts,
-        maps,
-        recipeOverrides,
-        resolvedSCCIds,
-        manualRawMaterials,
-      );
-    }
-
-    // Assemble full facility counts
-    console.log(`  Solution found:`);
-    for (let j = 0; j < m; j++) {
-      let facilityCount: number;
-      if (pinnedRecipes.has(j)) {
-        facilityCount = pinnedRecipes.get(j)!;
-      } else {
-        const freeIdx = freeIndices.indexOf(j);
-        facilityCount = Math.max(0, freeSolution[freeIdx]);
-      }
-      recipeFacilityCounts.set(recipesList[j].id, facilityCount);
-      console.log(
-        `    Recipe ${recipesList[j].id}: ${facilityCount.toFixed(4)} facilities${pinnedRecipes.has(j) ? " (pinned)" : ""}`,
-      );
-    }
-  } else {
-    // No pinned recipes — standard linear system solve.
-    const rawRows: SystemRow[] = [];
-
-    for (let i = 0; i < n; i++) {
-      const itemId = itemsList[i];
-      const row = new Array(m).fill(0);
-      const rhs = externalDemands.get(itemId) || 0;
-
-      for (let j = 0; j < m; j++) {
-        const recipe = recipesList[j];
-        const output =
-          recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
-        const input =
-          recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
-        row[j] =
-          calcRate(output, recipe.craftingTime) -
-          calcRate(input, recipe.craftingTime);
-      }
-
-      rawRows.push({ row, rhs, itemId });
-    }
-
-    const filteredRows = filterImpossibleDisposalRows(
-      rawRows,
-      m,
-      graph.rawMaterials,
-    );
-    const matrix = filteredRows.map((e) => e.row);
-    const constants = filteredRows.map((e) => e.rhs);
-    const effectiveN = filteredRows.length;
-
-    console.log(
-      `  Building linear system: ${effectiveN} items × ${m} recipes (${n - effectiveN} disposal rows filtered)`,
-    );
-    filteredRows.forEach(({ row, rhs, itemId }, i) => {
-      console.log(
-        `    Equation ${i} (${itemId}):`,
-        row.map((v, j) => `${v.toFixed(2)}*r${j}`).join(" + "),
-        `= ${rhs.toFixed(4)}`,
-      );
-    });
-
-    const solution =
-      effectiveN === 0
-        ? new Array(m).fill(0)
-        : solveOverdetermined(matrix, constants, m);
-
-    if (!solution) {
-      console.warn(
-        `  [SCC_SOLVE] Cannot solve SCC ${scc.id} - system has no solution`,
-      );
-      return tryExtendSCCWithFeeders(
-        scc,
-        graph,
-        itemDemands,
-        recipeFacilityCounts,
-        maps,
-        recipeOverrides,
-        resolvedSCCIds,
-        manualRawMaterials,
-      );
-    }
-
-    console.log(`  Solution found:`);
-    for (let j = 0; j < m; j++) {
-      const facilityCount = Math.max(0, solution[j]);
-      recipeFacilityCounts.set(recipesList[j].id, facilityCount);
-      console.log(
-        `    Recipe ${recipesList[j].id}: ${facilityCount.toFixed(4)} facilities`,
-      );
-    }
-  }
-
-  // --- Phase 4: Compute deficits for SCC-internal items and propagate ---
-  // After solving, some internal items may have a net deficit (consumed more
-  // than produced within the SCC). Propagate deficits as demand to external
-  // producers (e.g., liquid_sewage deficit filled by furnace outside the SCC).
-  for (let i = 0; i < n; i++) {
-    const itemId = itemsList[i];
-    let netProduction = 0;
-
-    for (let j = 0; j < m; j++) {
-      const recipe = recipesList[j];
-      const facilityCount = recipeFacilityCounts.get(recipe.id) || 0;
-      const output =
-        recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
-      const input =
-        recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
-
-      netProduction +=
-        (calcRate(output, recipe.craftingTime) -
-          calcRate(input, recipe.craftingTime)) *
-        facilityCount;
-    }
-
-    const externalDemand = externalDemands.get(itemId) || 0;
-    const deficit = externalDemand - netProduction;
-
-    if (deficit > 1e-9) {
-      // This item needs external supply — set itemDemands so external
-      // producers (processed later in the condensed DAG walk) can satisfy it.
-      // Use Math.max rather than addition: the deficit already accounts for
-      // all external demand (including target rates from Phase 1), so adding
-      // would double-count any pre-existing demand in itemDemands.
-      itemDemands.set(itemId, Math.max(itemDemands.get(itemId) || 0, deficit));
-      console.log(
-        `  Item ${itemId} has deficit of ${deficit.toFixed(4)}/min — propagated to external producers`,
-      );
-    }
-  }
-
-  // --- Phase 5: Propagate demands to external inputs ---
-  scc.externalInputs.forEach((inputItemId) => {
-    let totalConsumption = 0;
-
-    scc.recipes.forEach((recipeId) => {
-      const recipe = maps.recipeMap.get(recipeId)!;
-      const facilityCount = recipeFacilityCounts.get(recipeId) || 0;
-      const input = recipe.inputs.find((i) => i.itemId === inputItemId);
-
-      if (input) {
-        const consumption =
-          calcRate(input.amount, recipe.craftingTime) * facilityCount;
-        totalConsumption += consumption;
-      }
-    });
-
-    if (totalConsumption > 0) {
-      itemDemands.set(
-        inputItemId,
-        (itemDemands.get(inputItemId) || 0) + totalConsumption,
-      );
-      console.log(
-        `  External input ${inputItemId} demand increased by: ${totalConsumption.toFixed(4)}/min`,
-      );
-    }
-  });
-
-  return true;
-}
-
-/**
- * Attempts to extend an unsolvable SCC by adding "feeder" recipes — alternative
- * recipes for overridden items that provide an external supply path.
- *
- * When a recipe override creates a closed cycle with zero net output (e.g.,
- * Iron Powder → Iron Nugget while Iron Nugget → Iron Powder), the linear system
- * is inconsistent. By adding the default recipe (e.g., Iron Ore → Iron Nugget)
- * into the SCC, the system becomes underdetermined and solvable, allowing the
- * override recipe to be used with an external supply chain feeding it.
- *
- * Returns true if the SCC was extended and successfully re-solved.
- */
-function tryExtendSCCWithFeeders(
-  scc: SCCInfo,
-  graph: BipartiteGraph,
-  itemDemands: Map<ItemId, number>,
-  recipeFacilityCounts: Map<RecipeId, number>,
-  maps: ProductionMaps,
-  recipeOverrides?: Map<ItemId, RecipeId>,
-  resolvedSCCIds?: Set<string>,
-  manualRawMaterials?: Set<ItemId>,
-): boolean {
-  if (!recipeOverrides || recipeOverrides.size === 0) return false;
-
-  // Find SCC items that have a user recipe override AND have alternative
-  // recipes not already in the SCC.
-  const feedersAdded: {
-    feederRecipe: Recipe;
-    overrideRecipeId: RecipeId;
-    overrideDemand: number;
-  }[] = [];
-
-  for (const itemId of scc.items) {
-    if (!recipeOverrides.has(itemId)) continue;
-
-    const overrideRecipeId = recipeOverrides.get(itemId)!;
-    if (!scc.recipes.has(overrideRecipeId)) continue;
-
-    // Find alternative recipes that produce this item and are NOT in the SCC
-    const alternatives = Array.from(maps.recipeMap.values()).filter(
-      (r) =>
-        r.id !== overrideRecipeId &&
-        !scc.recipes.has(r.id) &&
-        r.outputs.some((o) => o.itemId === itemId) &&
-        // Must have at least one input that is NOT internal to the SCC
-        // (otherwise it doesn't provide external supply)
-        r.inputs.some((inp) => !scc.items.has(inp.itemId)),
-    );
-
-    if (alternatives.length === 0) continue;
-
-    // Pick the best alternative using selectRecipe heuristic (avoids cycles)
-    const feeder = selectRecipe(alternatives, scc.items);
-
-    // Determine the demand for pinning the override recipe.
-    // This is the external demand on the overridden item specifically —
-    // it may be 0 if the target is a different SCC item.
-    let overrideDemand = 0;
-    if (graph.targets.has(itemId)) {
-      overrideDemand += itemDemands.get(itemId) || 0;
-    }
-    // Also include demand from external consumers
-    const consumers = graph.itemConsumedBy.get(itemId);
-    if (consumers) {
-      consumers.forEach((rid) => {
-        if (!scc.recipes.has(rid)) {
-          const fc = recipeFacilityCounts.get(rid) || 0;
-          const recipe = maps.recipeMap.get(rid)!;
-          const input = recipe.inputs.find((i) => i.itemId === itemId);
-          if (input) {
-            overrideDemand += calcRate(input.amount, recipe.craftingTime) * fc;
-          }
-        }
-      });
-    }
-
-    feedersAdded.push({
-      feederRecipe: feeder,
-      overrideRecipeId,
-      overrideDemand,
-    });
-  }
-
-  if (feedersAdded.length === 0) return false;
-
-  // --- Snapshot state before mutations so we can roll back on failure ---
-  const originalSCCRecipes = new Set(scc.recipes);
-  const originalExternalInputs = new Set(scc.externalInputs);
-  const addedRecipeIds: RecipeId[] = [];
-  const addedItemIds: ItemId[] = [];
-  const addedConsumptionEdges: { itemId: ItemId; recipeId: RecipeId }[] = [];
-
-  /**
-   * Undo all graph and SCC mutations made by this function. Called before
-   * returning false so that a failed extension leaves no orphan nodes or
-   * stale SCC entries (which would leak into involvedRecipeIds in the
-   * invalid-cycle warning, etc.).
-   */
-  const rollback = () => {
-    // Restore SCC sets
-    for (const id of scc.recipes) {
-      if (!originalSCCRecipes.has(id)) scc.recipes.delete(id);
-    }
-    for (const id of scc.externalInputs) {
-      if (!originalExternalInputs.has(id)) scc.externalInputs.delete(id);
-    }
-    // Remove newly added graph entries
-    for (const id of addedRecipeIds) {
-      graph.recipeNodes.delete(id);
-      graph.recipeInputs.delete(id);
-      graph.recipeOutputs.delete(id);
-      recipeFacilityCounts.delete(id);
-    }
-    for (const id of addedItemIds) {
-      graph.itemNodes.delete(id);
-      graph.rawMaterials.delete(id);
-    }
-    for (const { itemId, recipeId } of addedConsumptionEdges) {
-      graph.itemConsumedBy.get(itemId)?.delete(recipeId);
-    }
-  };
-
-  // --- Add feeder recipes to the bipartite graph and extend the SCC ---
-  for (const { feederRecipe } of feedersAdded) {
-    const facility = maps.facilityMap.get(feederRecipe.facilityId);
-    if (!facility) continue;
-
-    // Add recipe node to bipartite graph
-    if (!graph.recipeNodes.has(feederRecipe.id)) {
-      graph.recipeNodes.set(feederRecipe.id, {
-        recipeId: feederRecipe.id,
-        recipe: feederRecipe,
-        facility,
-      });
-      graph.recipeInputs.set(feederRecipe.id, new Set());
-      graph.recipeOutputs.set(feederRecipe.id, new Set());
-      addedRecipeIds.push(feederRecipe.id);
-    }
-
-    // Add output edges
-    for (const out of feederRecipe.outputs) {
-      graph.recipeOutputs.get(feederRecipe.id)!.add(out.itemId);
-      if (!graph.itemNodes.has(out.itemId)) {
-        const outItem = maps.itemMap.get(out.itemId);
-        if (outItem) {
-          graph.itemNodes.set(out.itemId, {
-            itemId: out.itemId,
-            item: outItem,
-            isRawMaterial: false,
-          });
-          addedItemIds.push(out.itemId);
-        }
-      }
-    }
-
-    // Add input edges and traverse feeder's dependencies
-    for (const inp of feederRecipe.inputs) {
-      graph.recipeInputs.get(feederRecipe.id)!.add(inp.itemId);
-      if (!graph.itemConsumedBy.has(inp.itemId)) {
-        graph.itemConsumedBy.set(inp.itemId, new Set());
-      }
-      graph.itemConsumedBy.get(inp.itemId)!.add(feederRecipe.id);
-      addedConsumptionEdges.push({
-        itemId: inp.itemId,
-        recipeId: feederRecipe.id,
-      });
-
-      // Ensure input item exists in the graph
-      if (!graph.itemNodes.has(inp.itemId)) {
-        const inpItem = maps.itemMap.get(inp.itemId);
-        if (inpItem) {
-          const isRaw =
-            forcedRawMaterials.has(inp.itemId) ||
-            (manualRawMaterials?.has(inp.itemId) ?? false);
-          graph.itemNodes.set(inp.itemId, {
-            itemId: inp.itemId,
-            item: inpItem,
-            isRawMaterial: isRaw,
-          });
-          if (isRaw) graph.rawMaterials.add(inp.itemId);
-          addedItemIds.push(inp.itemId);
-        }
-      }
-
-      // Track as external input to the SCC if not an SCC-internal item
-      if (!scc.items.has(inp.itemId)) {
-        scc.externalInputs.add(inp.itemId);
-      }
-    }
-
-    // Add feeder to the SCC's recipe set
-    scc.recipes.add(feederRecipe.id);
-
-    console.log(
-      `  [SCC_EXTEND] Added feeder recipe ${feederRecipe.id} to SCC ${scc.id}`,
-    );
-  }
-
-  // --- Rebuild and solve the extended linear system ---
-  // Rebuild both lists from the (potentially modified) SCC sets so that any
-  // new items or recipes introduced by feeder additions are included.
-  const extItemsList = Array.from(scc.items);
-  const extRecipesList = Array.from(scc.recipes).map(
-    (rid) => maps.recipeMap.get(rid)!,
-  );
-  const n = extItemsList.length;
-  const m = extRecipesList.length;
-
-  // Recompute external demands (same as Phase 1)
-  const externalDemands = new Map<ItemId, number>();
-  for (const itemId of scc.items) {
-    let demand = 0;
-    const consumers = graph.itemConsumedBy.get(itemId);
-    if (consumers) {
-      consumers.forEach((recipeId) => {
-        if (!scc.recipes.has(recipeId)) {
-          const fc = recipeFacilityCounts.get(recipeId) || 0;
-          const recipe = maps.recipeMap.get(recipeId)!;
-          const input = recipe.inputs.find((i) => i.itemId === itemId);
-          if (input) {
-            demand += calcRate(input.amount, recipe.craftingTime) * fc;
-          }
-        }
-      });
-    }
-    if (graph.targets.has(itemId)) {
-      demand += itemDemands.get(itemId) || 0;
-    }
-    if (demand > 0) externalDemands.set(itemId, demand);
-  }
-
-  // Pin override recipes to their demand
-  const pinnedRecipes = new Map<number, number>();
-  for (const { overrideRecipeId, overrideDemand } of feedersAdded) {
-    const overrideIdx = extRecipesList.findIndex(
-      (r) => r.id === overrideRecipeId,
-    );
-    if (overrideIdx === -1) continue;
-
-    // Pin the override recipe to satisfy its output demand
-    const overrideRecipe = extRecipesList[overrideIdx];
-    const outputItem = overrideRecipe.outputs.find((o) =>
-      scc.items.has(o.itemId),
-    );
-    if (!outputItem) continue;
-
-    const rate = calcRate(outputItem.amount, overrideRecipe.craftingTime);
-    if (rate > 0) {
-      pinnedRecipes.set(overrideIdx, overrideDemand / rate);
-      console.log(
-        `  [SCC_EXTEND] Pinning override recipe ${overrideRecipe.id} (index ${overrideIdx}) to ${(overrideDemand / rate).toFixed(4)} facilities`,
-      );
-    }
-  }
-
-  if (pinnedRecipes.size === 0) {
-    rollback();
-    return false;
-  }
-
-  // Build reduced system (same approach as Path A in solveSCCFlow)
-  const freeIndices = Array.from({ length: m }, (_, i) => i).filter(
-    (i) => !pinnedRecipes.has(i),
-  );
-  const freeM = freeIndices.length;
-
-  const extRawRows: SystemRow[] = [];
-
-  for (let i = 0; i < n; i++) {
-    const itemId = extItemsList[i];
-    const row = new Array(freeM).fill(0);
-    const externalDemand = externalDemands.get(itemId) || 0;
-    let rhs = externalDemand;
-
-    for (let j = 0; j < m; j++) {
-      const recipe = extRecipesList[j];
-      const output =
-        recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
-      const input =
-        recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
-      const coeff =
-        calcRate(output, recipe.craftingTime) -
-        calcRate(input, recipe.craftingTime);
-
-      if (pinnedRecipes.has(j)) {
-        rhs -= coeff * pinnedRecipes.get(j)!;
-      } else {
-        const freeIdx = freeIndices.indexOf(j);
-        row[freeIdx] = coeff;
-      }
-    }
-
-    extRawRows.push({ row, rhs, itemId });
-  }
-
-  const extFilteredRows = filterImpossibleDisposalRows(
-    extRawRows,
-    freeM,
-    graph.rawMaterials,
-  );
-  const matrix = extFilteredRows.map((e) => e.row);
-  const constants = extFilteredRows.map((e) => e.rhs);
-  const extEffectiveN = extFilteredRows.length;
-
-  console.log(
-    `  [SCC_EXTEND] Solving extended system: ${extEffectiveN} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${m} total)`,
-  );
-
-  const freeSolution = solveOverdetermined(matrix, constants, freeM);
-
-  if (!freeSolution) {
-    console.warn(
-      `  [SCC_EXTEND] Extended system still has no solution for SCC ${scc.id}`,
-    );
-    rollback();
-    return false;
-  }
-
-  // Assemble full facility counts
-  console.log(`  [SCC_EXTEND] Solution found:`);
-  for (let j = 0; j < m; j++) {
-    let facilityCount: number;
-    if (pinnedRecipes.has(j)) {
-      facilityCount = pinnedRecipes.get(j)!;
-    } else {
-      const freeIdx = freeIndices.indexOf(j);
-      facilityCount = Math.max(0, freeSolution[freeIdx]);
-    }
-    recipeFacilityCounts.set(extRecipesList[j].id, facilityCount);
-    console.log(
-      `    Recipe ${extRecipesList[j].id}: ${facilityCount.toFixed(4)} facilities${pinnedRecipes.has(j) ? " (pinned)" : ""}`,
-    );
-  }
-
-  // --- Phase 4: Compute deficits (same as solveSCCFlow) ---
-  for (let i = 0; i < n; i++) {
-    const itemId = extItemsList[i];
-    let netProduction = 0;
-
-    for (let j = 0; j < m; j++) {
-      const recipe = extRecipesList[j];
-      const facilityCount = recipeFacilityCounts.get(recipe.id) || 0;
-      const output =
-        recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
-      const input =
-        recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
-      netProduction +=
-        (calcRate(output, recipe.craftingTime) -
-          calcRate(input, recipe.craftingTime)) *
-        facilityCount;
-    }
-
-    const externalDemand = externalDemands.get(itemId) || 0;
-    const deficit = externalDemand - netProduction;
-
-    if (deficit > 1e-9) {
-      itemDemands.set(itemId, Math.max(itemDemands.get(itemId) || 0, deficit));
-      console.log(
-        `  [SCC_EXTEND] Item ${itemId} has deficit of ${deficit.toFixed(4)}/min — propagated`,
-      );
-    }
-  }
-
-  // --- Check: did the extension actually resolve the target demand? ---
-  // If a target item in the SCC still has an unresolved deficit, the extended
-  // system couldn't produce the demanded output (e.g., the override recipe
-  // works against the target by dismantling the item we're trying to produce).
-  // Return false so the SCC is marked invalid and a warning is shown.
-  for (let i = 0; i < n; i++) {
-    const itemId = extItemsList[i];
-    if (!graph.targets.has(itemId)) continue;
-
-    let targetNetProduction = 0;
-    for (let j = 0; j < m; j++) {
-      const recipe = extRecipesList[j];
-      const facilityCount = recipeFacilityCounts.get(recipe.id) || 0;
-      const output =
-        recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
-      const input =
-        recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
-      targetNetProduction +=
-        (calcRate(output, recipe.craftingTime) -
-          calcRate(input, recipe.craftingTime)) *
-        facilityCount;
-    }
-
-    const externalDemand = externalDemands.get(itemId) || 0;
-    if (externalDemand - targetNetProduction > 1e-9) {
-      console.warn(
-        `  [SCC_EXTEND] Target ${itemId} has unresolved deficit of ${(externalDemand - targetNetProduction).toFixed(4)}/min — extension failed`,
-      );
-      rollback();
-      return false;
-    }
-  }
-
-  // --- Phase 5: Propagate demands to external inputs ---
-  scc.externalInputs.forEach((inputItemId) => {
-    let totalConsumption = 0;
-    scc.recipes.forEach((recipeId) => {
-      const recipe = maps.recipeMap.get(recipeId)!;
-      const facilityCount = recipeFacilityCounts.get(recipeId) || 0;
-      const input = recipe.inputs.find((i) => i.itemId === inputItemId);
-      if (input) {
-        totalConsumption +=
-          calcRate(input.amount, recipe.craftingTime) * facilityCount;
-      }
-    });
-
-    if (totalConsumption > 0) {
-      itemDemands.set(
-        inputItemId,
-        (itemDemands.get(inputItemId) || 0) + totalConsumption,
-      );
-      console.log(
-        `  [SCC_EXTEND] External input ${inputItemId} demand: ${totalConsumption.toFixed(4)}/min`,
-      );
-    }
-  });
-
-  // Mark this SCC as resolved by feeder extension so it is excluded from
-  // detectedCycles (the cycle has been linearised and should not be rendered
-  // with backward edges in the visualization).
-  resolvedSCCIds?.add(scc.id);
-
-  return true;
-}
-
-/**
- * Injects disposal recipes for forced disposal items that have surplus production.
- * A disposal recipe is injected when a byproduct in `forcedDisposalItems` is produced
- * but not fully consumed by other recipes or target demands.
- */
 function injectDisposalRecipes(
   graph: BipartiteGraph,
   flowData: FlowData,
@@ -1431,12 +30,10 @@ function injectDisposalRecipes(
   targets: Array<{ itemId: ItemId; rate: number }>,
 ): void {
   for (const itemId of forcedDisposalItems) {
-    // Only inject for items that exist in this plan
     if (!graph.itemNodes.has(itemId)) continue;
     const itemNode = graph.itemNodes.get(itemId)!;
     if (itemNode.isRawMaterial) continue;
 
-    // Compute total production of this item across all recipes
     let totalProduction = 0;
     graph.recipeOutputs.forEach((outputItems, recipeId) => {
       if (outputItems.has(itemId)) {
@@ -1450,13 +47,11 @@ function injectDisposalRecipes(
       }
     });
 
-    // Compute total consumption by non-disposal recipes
     let totalConsumption = 0;
     const consumers = graph.itemConsumedBy.get(itemId);
     if (consumers) {
       for (const recipeId of consumers) {
         const recipe = maps.recipeMap.get(recipeId)!;
-        // Skip disposal recipes to avoid double-counting
         if (recipe.outputs.length === 0) continue;
         const facilityCount = flowData.recipeFacilityCounts.get(recipeId) || 0;
         const input = recipe.inputs.find((i) => i.itemId === itemId);
@@ -1467,23 +62,19 @@ function injectDisposalRecipes(
       }
     }
 
-    // Subtract target demand (user wants to collect this amount, not dispose)
     const targetDemand = targets.find((t) => t.itemId === itemId)?.rate || 0;
 
     const surplus = totalProduction - totalConsumption - targetDemand;
     if (surplus <= 0) continue;
 
-    // Find the matching disposal recipe
     const disposalRecipe = Array.from(maps.recipeMap.values()).find(
       (r) =>
         r.outputs.length === 0 && r.inputs.some((i) => i.itemId === itemId),
     );
     if (!disposalRecipe) continue;
 
-    // Already injected
     if (graph.recipeNodes.has(disposalRecipe.id)) continue;
 
-    // Compute disposal facility count
     const disposalInput = disposalRecipe.inputs.find(
       (i) => i.itemId === itemId,
     )!;
@@ -1493,11 +84,9 @@ function injectDisposalRecipes(
     );
     const disposalFacilityCount = surplus / disposalRatePerFacility;
 
-    // Resolve facility
     const facility = maps.facilityMap.get(disposalRecipe.facilityId);
     if (!facility) continue;
 
-    // Inject into graph structures
     graph.recipeNodes.set(disposalRecipe.id, {
       recipeId: disposalRecipe.id,
       recipe: disposalRecipe,
@@ -1506,13 +95,11 @@ function injectDisposalRecipes(
     graph.recipeInputs.set(disposalRecipe.id, new Set([itemId]));
     graph.recipeOutputs.set(disposalRecipe.id, new Set());
 
-    // Add consumption edge
     if (!graph.itemConsumedBy.has(itemId)) {
       graph.itemConsumedBy.set(itemId, new Set());
     }
     graph.itemConsumedBy.get(itemId)!.add(disposalRecipe.id);
 
-    // Record facility count in flow data
     flowData.recipeFacilityCounts.set(disposalRecipe.id, disposalFacilityCount);
   }
 }
@@ -1528,16 +115,12 @@ function buildProductionGraph(
   const nodes = new Map<string, ProductionGraphNode>();
   const edges: Array<{ from: string; to: string }> = [];
 
-  // Add item nodes
   graph.itemNodes.forEach((itemNode, itemId) => {
     let productionRate = 0;
 
     if (itemNode.isRawMaterial) {
       productionRate = flowData.itemDemands.get(itemId) || 0;
     } else {
-      // Sum production from ALL recipes that output this item.
-      // An item can be produced by multiple recipes (e.g., as a primary output
-      // of one recipe and a byproduct of another).
       graph.recipeOutputs.forEach((outputItems, recipeId) => {
         if (outputItems.has(itemId)) {
           const recipe = maps.recipeMap.get(recipeId)!;
@@ -1561,7 +144,7 @@ function buildProductionGraph(
       isTarget: graph.targets.has(itemId),
     });
   });
-  // Add recipe nodes
+
   graph.recipeNodes.forEach((recipeData, recipeId) => {
     nodes.set(recipeId, {
       type: "recipe",
@@ -1573,22 +156,18 @@ function buildProductionGraph(
     });
   });
 
-  // Build edges: Item → Recipe (consume)
   graph.itemConsumedBy.forEach((recipeIds, itemId) => {
     recipeIds.forEach((recipeId) => {
       edges.push({ from: itemId, to: recipeId });
     });
   });
 
-  // Build edges: Recipe → Item (produce)
   graph.recipeOutputs.forEach((itemIds, recipeId) => {
     itemIds.forEach((itemId) => {
       edges.push({ from: recipeId, to: itemId });
     });
   });
 
-  // Build cycle info — exclude SCCs that were resolved by feeder extension
-  // since they are now linear chains, not true production cycles.
   const activeSCCs = sccs.filter((scc) => !flowData.resolvedSCCIds.has(scc.id));
   const detectedCycles: DetectedCycle[] = activeSCCs.map((scc) => {
     const cycleNodes: ProductionNode[] = Array.from(scc.recipes).flatMap(
@@ -1621,7 +200,6 @@ function buildProductionGraph(
     };
   });
 
-  // Build invalid cycle info from unresolved SCCs
   const invalidCycles: InvalidCycleInfo[] = invalidSCCs.map((info) => ({
     cycleId: info.sccId,
     involvedItemIds: Array.from(info.involvedItems),
@@ -1643,10 +221,6 @@ function buildProductionGraph(
   };
 }
 
-/**
- * Try to backtrack recipe choices to avoid invalid SCCs
- * Returns updated recipe constraints or null if no more options
- */
 function backtrackRecipeChoices(
   recipeChoices: Map<ItemId, RecipeChoice>,
   invalidSCCs: InvalidSCCInfo[],
@@ -1660,7 +234,6 @@ function backtrackRecipeChoices(
     `[BACKTRACK] Attempting to backtrack for ${invalidSCCs.length} invalid SCCs`,
   );
 
-  // Collect all items involved in invalid SCCs
   const problematicItems = new Set<ItemId>();
   invalidSCCs.forEach((scc) => {
     scc.involvedItems.forEach((itemId) => problematicItems.add(itemId));
@@ -1670,25 +243,21 @@ function backtrackRecipeChoices(
     `[BACKTRACK] Problematic items: ${Array.from(problematicItems).join(", ")}`,
   );
 
-  // Find items with alternative recipe choices, prioritizing items in invalid SCCs
   const itemsWithChoices = Array.from(recipeChoices.values())
     .filter((choice) => problematicItems.has(choice.itemId))
-    .sort((a, b) => b.currentIndex - a.currentIndex); // Start from items that have tried fewer options
+    .sort((a, b) => b.currentIndex - a.currentIndex);
 
   if (itemsWithChoices.length === 0) {
-    // No items with multiple choices in the problematic set
     console.log(
       `[BACKTRACK] No alternative recipes available for problematic items`,
     );
     return null;
   }
 
-  // Try to find the next recipe choice
   for (const choice of itemsWithChoices) {
     const nextIndex = choice.currentIndex + 1;
 
     if (nextIndex < choice.availableRecipes.length) {
-      // Found an item with an untried recipe
       console.log(
         `[BACKTRACK] Trying next recipe for item ${choice.itemId}: ` +
           `index ${nextIndex}/${choice.availableRecipes.length}`,
@@ -1696,7 +265,6 @@ function backtrackRecipeChoices(
 
       const newConstraints = new Map(currentConstraints);
 
-      // Exclude all recipes up to and including current index
       const excludedRecipes = new Set(
         currentConstraints.get(choice.itemId) || [],
       );
@@ -1705,7 +273,6 @@ function backtrackRecipeChoices(
       }
       newConstraints.set(choice.itemId, excludedRecipes);
 
-      // Update the choice index
       choice.currentIndex = nextIndex;
 
       return newConstraints;
@@ -1761,7 +328,6 @@ export function calculateProductionPlan(
     );
 
     if (invalidSCCs.length === 0) {
-      // Success! No invalid SCCs found
       console.log(
         `[SUCCESS] Valid production plan found in ${iteration} iteration(s)`,
       );
@@ -1776,7 +342,6 @@ export function calculateProductionPlan(
       );
     }
 
-    // Try to backtrack
     console.log(
       `[ITERATION ${iteration}] Found ${invalidSCCs.length} invalid SCC(s), attempting backtrack`,
     );
@@ -1788,7 +353,6 @@ export function calculateProductionPlan(
     );
 
     if (newConstraints === null) {
-      // No more recipe combinations to try
       console.warn(
         `[FAILED] Cannot find valid production plan after ${iteration} iterations. ` +
           `Returning best-effort result with ${invalidSCCs.length} invalid cycle(s).`,

--- a/src/lib/calculator.ts
+++ b/src/lib/calculator.ts
@@ -17,17 +17,39 @@ import { calcRate } from "@/lib/utils";
 
 type SystemRow = { row: number[]; rhs: number; itemId: ItemId };
 
-// Drop rows for forced-disposal items whose LHS is all-zero with a non-zero RHS:
-// such equations are unsatisfiable in the linear system but the surplus they
-// represent is handled later by injectDisposalRecipes, so we must not let them
-// force the solver into "no solution".
-const filterImpossibleDisposalRows = (rows: SystemRow[]): SystemRow[] =>
-  rows.filter(
+const isAllZeroRow = (row: number[]): boolean =>
+  row.every((v) => Math.abs(v) < 1e-9);
+
+// Drops equations the SCC solver must not enforce:
+//   1. Unsatisfiable: forced-disposal item with zero LHS and non-zero RHS —
+//      surplus is handled later by injectDisposalRecipes.
+//   2. Slack: forced-disposal-surplus (rhs <= 0) or forced-raw-supply items,
+//      dropped greedily while keeping at least numVars rows so the system
+//      stays determined. Raw-material rows go first (deficit always absorbed
+//      by external supply); disposal rows may still carry balance info.
+const filterImpossibleDisposalRows = (
+  rows: SystemRow[],
+  numVars: number,
+  rawMaterials: Set<ItemId>,
+): SystemRow[] => {
+  const base = rows.filter(
     ({ row, rhs, itemId }) =>
       !forcedDisposalItems.has(itemId) ||
-      row.some((v) => Math.abs(v) > 1e-9) ||
+      !isAllZeroRow(row) ||
       Math.abs(rhs) < 1e-9,
   );
+  const isRawSlack = (r: SystemRow) => rawMaterials.has(r.itemId);
+  const isDisposalSlack = (r: SystemRow) =>
+    forcedDisposalItems.has(r.itemId) && r.rhs <= 1e-9;
+  const remaining = base.slice();
+  for (const isSlack of [isRawSlack, isDisposalSlack]) {
+    for (let i = remaining.length - 1; i >= 0; i--) {
+      if (remaining.length <= numVars) break;
+      if (isSlack(remaining[i])) remaining.splice(i, 1);
+    }
+  }
+  return remaining;
+};
 
 // Dismantler recipes consume fbottle_* items (bottled products) as inputs.
 // They are reverse/recovery recipes and should be deprioritized during auto-selection
@@ -646,35 +668,40 @@ function solveSCCFlow(
 
   // --- Phase 2: Compute external output demands ---
   // Items OUTSIDE the SCC that are produced by SCC recipes and have demand.
-  // These constrain ("pin") the facility counts for the producing recipes.
-  const externalOutputDemands = new Map<
-    number,
-    { itemId: ItemId; demand: number; rate: number }[]
+  // Group by external item so multi-producer cases can share a single
+  // constraint (sum rate_j * r_j = demand) rather than pinning each recipe
+  // independently to demand/rate (which would overdetermine the system with
+  // total output = k × demand).
+  const externalOutputByItem = new Map<
+    ItemId,
+    { demand: number; producers: { recipeIdx: number; rate: number }[] }
   >();
-  let hasExternalOutputDemand = false;
 
   for (let j = 0; j < m; j++) {
     const recipe = recipesList[j];
-    const demands: { itemId: ItemId; demand: number; rate: number }[] = [];
 
     for (const out of recipe.outputs) {
       if (scc.items.has(out.itemId)) continue; // Skip SCC-internal items
 
       const demand = itemDemands.get(out.itemId) || 0;
-      if (demand > 0) {
-        const rate = calcRate(out.amount, recipe.craftingTime);
-        demands.push({ itemId: out.itemId, demand, rate });
-        console.log(
-          `    Recipe ${recipe.id} produces external item ${out.itemId} with demand: ${demand.toFixed(4)}/min (rate: ${rate.toFixed(4)}/facility)`,
-        );
-      }
-    }
+      if (demand <= 0) continue;
 
-    if (demands.length > 0) {
-      externalOutputDemands.set(j, demands);
-      hasExternalOutputDemand = true;
+      const rate = calcRate(out.amount, recipe.craftingTime);
+      if (rate <= 0) continue;
+
+      let entry = externalOutputByItem.get(out.itemId);
+      if (!entry) {
+        entry = { demand, producers: [] };
+        externalOutputByItem.set(out.itemId, entry);
+      }
+      entry.producers.push({ recipeIdx: j, rate });
+      console.log(
+        `    Recipe ${recipe.id} produces external item ${out.itemId} with demand: ${demand.toFixed(4)}/min (rate: ${rate.toFixed(4)}/facility)`,
+      );
     }
   }
+
+  const hasExternalOutputDemand = externalOutputByItem.size > 0;
 
   // Early exit if no demand at all (neither internal nor external output)
   if (externalDemands.size === 0 && !hasExternalOutputDemand) {
@@ -693,27 +720,35 @@ function solveSCCFlow(
   }
 
   console.log(
-    `  External demands (internal items): ${externalDemands.size}, External output demands: ${externalOutputDemands.size}`,
+    `  External demands (internal items): ${externalDemands.size}, External output items: ${externalOutputByItem.size}`,
   );
 
   // --- Phase 3: Solve with pinned facility counts ---
-  // Pin facility counts for recipes that produce external items with demand.
+  // Single-producer external items → pin that recipe to demand/rate.
+  // Multi-producer external items → leave recipes free, add a shared
+  // constraint row (sum rate_j * r_j = demand) so the solver distributes
+  // demand across producers.
   const pinnedRecipes = new Map<number, number>(); // recipe index → facility count
+  const sharedOutputConstraints: { itemId: ItemId; demand: number }[] = [];
 
-  externalOutputDemands.forEach((demands, j) => {
-    let pinnedCount = 0;
-    for (const { demand, rate } of demands) {
-      if (rate > 0) {
-        pinnedCount = Math.max(pinnedCount, demand / rate);
-      }
+  externalOutputByItem.forEach(({ demand, producers }, itemId) => {
+    if (producers.length === 1) {
+      const { recipeIdx, rate } = producers[0];
+      const pinnedCount = demand / rate;
+      const prev = pinnedRecipes.get(recipeIdx) ?? 0;
+      pinnedRecipes.set(recipeIdx, Math.max(prev, pinnedCount));
+      console.log(
+        `  Pinning recipe ${recipesList[recipeIdx].id} (index ${recipeIdx}) to ${pinnedCount.toFixed(4)} facilities (single producer of ${itemId})`,
+      );
+    } else {
+      sharedOutputConstraints.push({ itemId, demand });
+      console.log(
+        `  Shared constraint: ${producers.length} producers of external ${itemId} (total demand ${demand.toFixed(4)}/min)`,
+      );
     }
-    pinnedRecipes.set(j, pinnedCount);
-    console.log(
-      `  Pinning recipe ${recipesList[j].id} (index ${j}) to ${pinnedCount.toFixed(4)} facilities`,
-    );
   });
 
-  if (pinnedRecipes.size > 0) {
+  if (pinnedRecipes.size > 0 || sharedOutputConstraints.length > 0) {
     // Build reduced system: substitute pinned values, solve for remaining recipes
     const freeIndices = Array.from({ length: m }, (_, i) => i).filter(
       (i) => !pinnedRecipes.has(i),
@@ -725,7 +760,8 @@ function solveSCCFlow(
     for (let i = 0; i < n; i++) {
       const itemId = itemsList[i];
       const row = new Array(freeM).fill(0);
-      let rhs = externalDemands.get(itemId) || 0;
+      const externalDemand = externalDemands.get(itemId) || 0;
+      let rhs = externalDemand;
 
       for (let j = 0; j < m; j++) {
         const recipe = recipesList[j];
@@ -748,13 +784,29 @@ function solveSCCFlow(
       rawRows.push({ row, rhs, itemId });
     }
 
-    const filteredRows = filterImpossibleDisposalRows(rawRows);
+    // Shared constraint rows: sum(rate_j * r_j) = demand for each
+    // multi-producer external item.
+    for (const { itemId, demand } of sharedOutputConstraints) {
+      const row = new Array(freeM).fill(0);
+      const producers = externalOutputByItem.get(itemId)!.producers;
+      for (const { recipeIdx, rate } of producers) {
+        const freeIdx = freeIndices.indexOf(recipeIdx);
+        if (freeIdx >= 0) row[freeIdx] += rate;
+      }
+      rawRows.push({ row, rhs: demand, itemId });
+    }
+
+    const filteredRows = filterImpossibleDisposalRows(
+      rawRows,
+      freeM,
+      graph.rawMaterials,
+    );
     const matrix = filteredRows.map((e) => e.row);
     const constants = filteredRows.map((e) => e.rhs);
     const effectiveN = filteredRows.length;
 
     console.log(
-      `  Building reduced system: ${effectiveN} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${n - effectiveN} disposal rows filtered)`,
+      `  Building reduced system: ${effectiveN} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${sharedOutputConstraints.length} shared-output constraints, ${n + sharedOutputConstraints.length - effectiveN} disposal rows filtered)`,
     );
     filteredRows.forEach(({ row, rhs, itemId }, i) => {
       console.log(
@@ -820,7 +872,11 @@ function solveSCCFlow(
       rawRows.push({ row, rhs, itemId });
     }
 
-    const filteredRows = filterImpossibleDisposalRows(rawRows);
+    const filteredRows = filterImpossibleDisposalRows(
+      rawRows,
+      m,
+      graph.rawMaterials,
+    );
     const matrix = filteredRows.map((e) => e.row);
     const constants = filteredRows.map((e) => e.rhs);
     const effectiveN = filteredRows.length;
@@ -1206,7 +1262,8 @@ function tryExtendSCCWithFeeders(
   for (let i = 0; i < n; i++) {
     const itemId = extItemsList[i];
     const row = new Array(freeM).fill(0);
-    let rhs = externalDemands.get(itemId) || 0;
+    const externalDemand = externalDemands.get(itemId) || 0;
+    let rhs = externalDemand;
 
     for (let j = 0; j < m; j++) {
       const recipe = extRecipesList[j];
@@ -1229,7 +1286,11 @@ function tryExtendSCCWithFeeders(
     extRawRows.push({ row, rhs, itemId });
   }
 
-  const extFilteredRows = filterImpossibleDisposalRows(extRawRows);
+  const extFilteredRows = filterImpossibleDisposalRows(
+    extRawRows,
+    freeM,
+    graph.rawMaterials,
+  );
   const matrix = extFilteredRows.map((e) => e.row);
   const constants = extFilteredRows.map((e) => e.rhs);
   const extEffectiveN = extFilteredRows.length;

--- a/src/lib/flow-solver.ts
+++ b/src/lib/flow-solver.ts
@@ -1,0 +1,879 @@
+import type { ItemId, RecipeId } from "@/types";
+import { solveOverdetermined } from "./linear-solver";
+import { forcedRawMaterials, forcedDisposalItems } from "@/data";
+import { calcRate } from "@/lib/utils";
+import { selectRecipe } from "./graph-builder";
+import type {
+  SystemRow,
+  ProductionMaps,
+  BipartiteGraph,
+  SCCInfo,
+  CondensedNode,
+  FlowData,
+  InvalidSCCInfo,
+} from "./calculator-types";
+
+const isAllZeroRow = (row: number[]): boolean =>
+  row.every((v) => Math.abs(v) < 1e-9);
+
+// Drops equations the SCC solver must not enforce:
+//   1. Unsatisfiable: forced-disposal item with zero LHS and non-zero RHS —
+//      surplus is handled later by injectDisposalRecipes.
+//   2. Slack: forced-disposal-surplus (rhs <= 0) or forced-raw-supply items,
+//      dropped greedily while keeping at least numVars rows so the system
+//      stays determined. Raw-material rows go first (deficit always absorbed
+//      by external supply); disposal rows may still carry balance info.
+const filterImpossibleDisposalRows = (
+  rows: SystemRow[],
+  numVars: number,
+  rawMaterials: Set<ItemId>,
+): SystemRow[] => {
+  const base = rows.filter(
+    ({ row, rhs, itemId }) =>
+      !forcedDisposalItems.has(itemId) ||
+      !isAllZeroRow(row) ||
+      Math.abs(rhs) < 1e-9,
+  );
+  const isRawSlack = (r: SystemRow) => rawMaterials.has(r.itemId);
+  const isDisposalSlack = (r: SystemRow) =>
+    forcedDisposalItems.has(r.itemId) && r.rhs <= 1e-9;
+  const remaining = base.slice();
+  for (const isSlack of [isRawSlack, isDisposalSlack]) {
+    for (let i = remaining.length - 1; i >= 0; i--) {
+      if (remaining.length <= numVars) break;
+      if (isSlack(remaining[i])) remaining.splice(i, 1);
+    }
+  }
+  return remaining;
+};
+
+export function calculateFlows(
+  graph: BipartiteGraph,
+  condensedOrder: CondensedNode[],
+  targetRates: Map<ItemId, number>,
+  maps: ProductionMaps,
+  recipeOverrides?: Map<ItemId, RecipeId>,
+  manualRawMaterials?: Set<ItemId>,
+): { flowData: FlowData; invalidSCCs: InvalidSCCInfo[] } {
+  const itemDemands = new Map<ItemId, number>();
+  const recipeFacilityCounts = new Map<RecipeId, number>();
+  const resolvedSCCIds = new Set<string>();
+  const invalidSCCs: InvalidSCCInfo[] = [];
+
+  targetRates.forEach((rate, itemId) => {
+    itemDemands.set(itemId, rate);
+  });
+
+  const reversedOrder = [...condensedOrder].reverse();
+
+  console.log(
+    `[FLOW] Processing ${reversedOrder.length} condensed nodes in topological order`,
+  );
+
+  reversedOrder.forEach((node, idx) => {
+    if (node.type === "scc") {
+      console.log(`[FLOW] [${idx}] Processing SCC: ${node.scc.id}`);
+      const solved = solveSCCFlow(
+        node.scc,
+        graph,
+        itemDemands,
+        recipeFacilityCounts,
+        maps,
+        recipeOverrides,
+        resolvedSCCIds,
+        manualRawMaterials,
+      );
+
+      if (!solved) {
+        const reason =
+          node.scc.externalInputs.size === 0
+            ? "no_external_demand"
+            : "no_solution";
+        invalidSCCs.push({
+          sccId: node.scc.id,
+          involvedItems: node.scc.items,
+          reason,
+        });
+        console.log(
+          `  [FLOW] Recorded invalid SCC: ${node.scc.id} (${reason})`,
+        );
+      }
+    } else if (node.type === "recipe") {
+      console.log(`[FLOW] [${idx}] Processing recipe: ${node.recipeId}`);
+      const recipeData = graph.recipeNodes.get(node.recipeId)!;
+      const recipe = recipeData.recipe;
+
+      const outputs = graph.recipeOutputs.get(node.recipeId)!;
+
+      let facilityCount = 0;
+
+      outputs.forEach((itemId) => {
+        const demand = itemDemands.get(itemId) || 0;
+        const output = recipe.outputs.find((o) => o.itemId === itemId);
+        if (!output) return;
+
+        const rate = calcRate(output.amount, recipe.craftingTime);
+        if (rate > 0) {
+          facilityCount = Math.max(facilityCount, demand / rate);
+        }
+      });
+
+      recipeFacilityCounts.set(node.recipeId, facilityCount);
+      console.log(`  Facility count: ${facilityCount.toFixed(4)}`);
+
+      recipe.inputs.forEach((input) => {
+        const inputDemand =
+          calcRate(input.amount, recipe.craftingTime) * facilityCount;
+        itemDemands.set(
+          input.itemId,
+          (itemDemands.get(input.itemId) || 0) + inputDemand,
+        );
+      });
+    } else if (node.type === "item") {
+      console.log(`[FLOW] [${idx}] Processing item: ${node.itemId}`);
+    }
+  });
+
+  return {
+    flowData: { itemDemands, recipeFacilityCounts, resolvedSCCIds },
+    invalidSCCs,
+  };
+}
+
+function solveSCCFlow(
+  scc: SCCInfo,
+  graph: BipartiteGraph,
+  itemDemands: Map<ItemId, number>,
+  recipeFacilityCounts: Map<RecipeId, number>,
+  maps: ProductionMaps,
+  recipeOverrides?: Map<ItemId, RecipeId>,
+  resolvedSCCIds?: Set<string>,
+  manualRawMaterials?: Set<ItemId>,
+): boolean {
+  console.log(`[SCC_SOLVE] Solving flow for SCC: ${scc.id}`);
+
+  const recipesList = Array.from(scc.recipes).map(
+    (rid) => maps.recipeMap.get(rid)!,
+  );
+  const itemsList = Array.from(scc.items);
+  const n = itemsList.length;
+  const m = recipesList.length;
+
+  if (m === 0 || n === 0) {
+    console.log(`  [SCC_SOLVE] Empty system, skipping`);
+    return false;
+  }
+
+  // --- Phase 1: Compute external demands for SCC-internal items ---
+  const externalDemands = new Map<ItemId, number>();
+
+  scc.items.forEach((itemId) => {
+    let demand = 0;
+
+    const consumers = graph.itemConsumedBy.get(itemId);
+    if (consumers) {
+      consumers.forEach((recipeId) => {
+        if (!scc.recipes.has(recipeId)) {
+          const facilityCount = recipeFacilityCounts.get(recipeId) || 0;
+          const recipe = maps.recipeMap.get(recipeId)!;
+          const input = recipe.inputs.find((i) => i.itemId === itemId);
+          if (input) {
+            const consumption =
+              calcRate(input.amount, recipe.craftingTime) * facilityCount;
+            demand += consumption;
+            console.log(
+              `    Item ${itemId} consumed by external recipe ${recipeId}: ${consumption.toFixed(4)}`,
+            );
+          }
+        }
+      });
+    }
+
+    if (graph.targets.has(itemId)) {
+      const targetDemand = itemDemands.get(itemId) || 0;
+      demand += targetDemand;
+      console.log(
+        `    Item ${itemId} is target with demand: ${targetDemand.toFixed(4)}`,
+      );
+    }
+
+    if (demand > 0) {
+      externalDemands.set(itemId, demand);
+    }
+  });
+
+  // --- Phase 2: Compute external output demands ---
+  const externalOutputByItem = new Map<
+    ItemId,
+    { demand: number; producers: { recipeIdx: number; rate: number }[] }
+  >();
+
+  for (let j = 0; j < m; j++) {
+    const recipe = recipesList[j];
+
+    for (const out of recipe.outputs) {
+      if (scc.items.has(out.itemId)) continue;
+
+      const demand = itemDemands.get(out.itemId) || 0;
+      if (demand <= 0) continue;
+
+      const rate = calcRate(out.amount, recipe.craftingTime);
+      if (rate <= 0) continue;
+
+      let entry = externalOutputByItem.get(out.itemId);
+      if (!entry) {
+        entry = { demand, producers: [] };
+        externalOutputByItem.set(out.itemId, entry);
+      }
+      entry.producers.push({ recipeIdx: j, rate });
+      console.log(
+        `    Recipe ${recipe.id} produces external item ${out.itemId} with demand: ${demand.toFixed(4)}/min (rate: ${rate.toFixed(4)}/facility)`,
+      );
+    }
+  }
+
+  const hasExternalOutputDemand = externalOutputByItem.size > 0;
+
+  if (externalDemands.size === 0 && !hasExternalOutputDemand) {
+    console.log(`  [SCC_SOLVE] No external demand, this is an invalid cycle`);
+    return tryExtendSCCWithFeeders(
+      scc,
+      graph,
+      itemDemands,
+      recipeFacilityCounts,
+      maps,
+      recipeOverrides,
+      resolvedSCCIds,
+      manualRawMaterials,
+    );
+  }
+
+  console.log(
+    `  External demands (internal items): ${externalDemands.size}, External output items: ${externalOutputByItem.size}`,
+  );
+
+  // --- Phase 3: Solve with pinned facility counts ---
+  const pinnedRecipes = new Map<number, number>();
+  const sharedOutputConstraints: { itemId: ItemId; demand: number }[] = [];
+
+  externalOutputByItem.forEach(({ demand, producers }, itemId) => {
+    if (producers.length === 1) {
+      const { recipeIdx, rate } = producers[0];
+      const pinnedCount = demand / rate;
+      const prev = pinnedRecipes.get(recipeIdx) ?? 0;
+      pinnedRecipes.set(recipeIdx, Math.max(prev, pinnedCount));
+      console.log(
+        `  Pinning recipe ${recipesList[recipeIdx].id} (index ${recipeIdx}) to ${pinnedCount.toFixed(4)} facilities (single producer of ${itemId})`,
+      );
+    } else {
+      sharedOutputConstraints.push({ itemId, demand });
+      console.log(
+        `  Shared constraint: ${producers.length} producers of external ${itemId} (total demand ${demand.toFixed(4)}/min)`,
+      );
+    }
+  });
+
+  if (pinnedRecipes.size > 0 || sharedOutputConstraints.length > 0) {
+    const freeIndices = Array.from({ length: m }, (_, i) => i).filter(
+      (i) => !pinnedRecipes.has(i),
+    );
+    const freeM = freeIndices.length;
+
+    const rawRows: SystemRow[] = [];
+
+    for (let i = 0; i < n; i++) {
+      const itemId = itemsList[i];
+      const row = new Array(freeM).fill(0);
+      const externalDemand = externalDemands.get(itemId) || 0;
+      let rhs = externalDemand;
+
+      for (let j = 0; j < m; j++) {
+        const recipe = recipesList[j];
+        const output =
+          recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
+        const input =
+          recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
+        const coeff =
+          calcRate(output, recipe.craftingTime) -
+          calcRate(input, recipe.craftingTime);
+
+        if (pinnedRecipes.has(j)) {
+          rhs -= coeff * pinnedRecipes.get(j)!;
+        } else {
+          const freeIdx = freeIndices.indexOf(j);
+          row[freeIdx] = coeff;
+        }
+      }
+
+      rawRows.push({ row, rhs, itemId });
+    }
+
+    for (const { itemId, demand } of sharedOutputConstraints) {
+      const row = new Array(freeM).fill(0);
+      const producers = externalOutputByItem.get(itemId)!.producers;
+      for (const { recipeIdx, rate } of producers) {
+        const freeIdx = freeIndices.indexOf(recipeIdx);
+        if (freeIdx >= 0) row[freeIdx] += rate;
+      }
+      rawRows.push({ row, rhs: demand, itemId });
+    }
+
+    const filteredRows = filterImpossibleDisposalRows(
+      rawRows,
+      freeM,
+      graph.rawMaterials,
+    );
+    const matrix = filteredRows.map((e) => e.row);
+    const constants = filteredRows.map((e) => e.rhs);
+    const effectiveN = filteredRows.length;
+
+    console.log(
+      `  Building reduced system: ${effectiveN} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${sharedOutputConstraints.length} shared-output constraints, ${n + sharedOutputConstraints.length - effectiveN} disposal rows filtered)`,
+    );
+    filteredRows.forEach(({ row, rhs, itemId }, i) => {
+      console.log(
+        `    Equation ${i} (${itemId}):`,
+        row.map((v, fi) => `${v.toFixed(2)}*r${freeIndices[fi]}`).join(" + "),
+        `= ${rhs.toFixed(4)}`,
+      );
+    });
+
+    const freeSolution = solveOverdetermined(matrix, constants, freeM);
+
+    if (!freeSolution) {
+      console.warn(
+        `  [SCC_SOLVE] Cannot solve reduced SCC ${scc.id} - system has no solution`,
+      );
+      return tryExtendSCCWithFeeders(
+        scc,
+        graph,
+        itemDemands,
+        recipeFacilityCounts,
+        maps,
+        recipeOverrides,
+        resolvedSCCIds,
+        manualRawMaterials,
+      );
+    }
+
+    console.log(`  Solution found:`);
+    for (let j = 0; j < m; j++) {
+      let facilityCount: number;
+      if (pinnedRecipes.has(j)) {
+        facilityCount = pinnedRecipes.get(j)!;
+      } else {
+        const freeIdx = freeIndices.indexOf(j);
+        facilityCount = Math.max(0, freeSolution[freeIdx]);
+      }
+      recipeFacilityCounts.set(recipesList[j].id, facilityCount);
+      console.log(
+        `    Recipe ${recipesList[j].id}: ${facilityCount.toFixed(4)} facilities${pinnedRecipes.has(j) ? " (pinned)" : ""}`,
+      );
+    }
+  } else {
+    const rawRows: SystemRow[] = [];
+
+    for (let i = 0; i < n; i++) {
+      const itemId = itemsList[i];
+      const row = new Array(m).fill(0);
+      const rhs = externalDemands.get(itemId) || 0;
+
+      for (let j = 0; j < m; j++) {
+        const recipe = recipesList[j];
+        const output =
+          recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
+        const input =
+          recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
+        row[j] =
+          calcRate(output, recipe.craftingTime) -
+          calcRate(input, recipe.craftingTime);
+      }
+
+      rawRows.push({ row, rhs, itemId });
+    }
+
+    const filteredRows = filterImpossibleDisposalRows(
+      rawRows,
+      m,
+      graph.rawMaterials,
+    );
+    const matrix = filteredRows.map((e) => e.row);
+    const constants = filteredRows.map((e) => e.rhs);
+    const effectiveN = filteredRows.length;
+
+    console.log(
+      `  Building linear system: ${effectiveN} items × ${m} recipes (${n - effectiveN} disposal rows filtered)`,
+    );
+    filteredRows.forEach(({ row, rhs, itemId }, i) => {
+      console.log(
+        `    Equation ${i} (${itemId}):`,
+        row.map((v, j) => `${v.toFixed(2)}*r${j}`).join(" + "),
+        `= ${rhs.toFixed(4)}`,
+      );
+    });
+
+    const solution =
+      effectiveN === 0
+        ? new Array(m).fill(0)
+        : solveOverdetermined(matrix, constants, m);
+
+    if (!solution) {
+      console.warn(
+        `  [SCC_SOLVE] Cannot solve SCC ${scc.id} - system has no solution`,
+      );
+      return tryExtendSCCWithFeeders(
+        scc,
+        graph,
+        itemDemands,
+        recipeFacilityCounts,
+        maps,
+        recipeOverrides,
+        resolvedSCCIds,
+        manualRawMaterials,
+      );
+    }
+
+    console.log(`  Solution found:`);
+    for (let j = 0; j < m; j++) {
+      const facilityCount = Math.max(0, solution[j]);
+      recipeFacilityCounts.set(recipesList[j].id, facilityCount);
+      console.log(
+        `    Recipe ${recipesList[j].id}: ${facilityCount.toFixed(4)} facilities`,
+      );
+    }
+  }
+
+  // --- Phase 4: Compute deficits for SCC-internal items and propagate ---
+  for (let i = 0; i < n; i++) {
+    const itemId = itemsList[i];
+    let netProduction = 0;
+
+    for (let j = 0; j < m; j++) {
+      const recipe = recipesList[j];
+      const facilityCount = recipeFacilityCounts.get(recipe.id) || 0;
+      const output =
+        recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
+      const input =
+        recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
+
+      netProduction +=
+        (calcRate(output, recipe.craftingTime) -
+          calcRate(input, recipe.craftingTime)) *
+        facilityCount;
+    }
+
+    const externalDemand = externalDemands.get(itemId) || 0;
+    const deficit = externalDemand - netProduction;
+
+    if (deficit > 1e-9) {
+      itemDemands.set(itemId, Math.max(itemDemands.get(itemId) || 0, deficit));
+      console.log(
+        `  Item ${itemId} has deficit of ${deficit.toFixed(4)}/min — propagated to external producers`,
+      );
+    }
+  }
+
+  // --- Phase 5: Propagate demands to external inputs ---
+  scc.externalInputs.forEach((inputItemId) => {
+    let totalConsumption = 0;
+
+    scc.recipes.forEach((recipeId) => {
+      const recipe = maps.recipeMap.get(recipeId)!;
+      const facilityCount = recipeFacilityCounts.get(recipeId) || 0;
+      const input = recipe.inputs.find((i) => i.itemId === inputItemId);
+
+      if (input) {
+        const consumption =
+          calcRate(input.amount, recipe.craftingTime) * facilityCount;
+        totalConsumption += consumption;
+      }
+    });
+
+    if (totalConsumption > 0) {
+      itemDemands.set(
+        inputItemId,
+        (itemDemands.get(inputItemId) || 0) + totalConsumption,
+      );
+      console.log(
+        `  External input ${inputItemId} demand increased by: ${totalConsumption.toFixed(4)}/min`,
+      );
+    }
+  });
+
+  return true;
+}
+
+function tryExtendSCCWithFeeders(
+  scc: SCCInfo,
+  graph: BipartiteGraph,
+  itemDemands: Map<ItemId, number>,
+  recipeFacilityCounts: Map<RecipeId, number>,
+  maps: ProductionMaps,
+  recipeOverrides?: Map<ItemId, RecipeId>,
+  resolvedSCCIds?: Set<string>,
+  manualRawMaterials?: Set<ItemId>,
+): boolean {
+  if (!recipeOverrides || recipeOverrides.size === 0) return false;
+
+  const feedersAdded: {
+    feederRecipe: import("@/types").Recipe;
+    overrideRecipeId: RecipeId;
+    overrideDemand: number;
+  }[] = [];
+
+  for (const itemId of scc.items) {
+    if (!recipeOverrides.has(itemId)) continue;
+
+    const overrideRecipeId = recipeOverrides.get(itemId)!;
+    if (!scc.recipes.has(overrideRecipeId)) continue;
+
+    const alternatives = Array.from(maps.recipeMap.values()).filter(
+      (r) =>
+        r.id !== overrideRecipeId &&
+        !scc.recipes.has(r.id) &&
+        r.outputs.some((o) => o.itemId === itemId) &&
+        r.inputs.some((inp) => !scc.items.has(inp.itemId)),
+    );
+
+    if (alternatives.length === 0) continue;
+
+    const feeder = selectRecipe(alternatives, scc.items);
+
+    let overrideDemand = 0;
+    if (graph.targets.has(itemId)) {
+      overrideDemand += itemDemands.get(itemId) || 0;
+    }
+    const consumers = graph.itemConsumedBy.get(itemId);
+    if (consumers) {
+      consumers.forEach((rid) => {
+        if (!scc.recipes.has(rid)) {
+          const fc = recipeFacilityCounts.get(rid) || 0;
+          const recipe = maps.recipeMap.get(rid)!;
+          const input = recipe.inputs.find((i) => i.itemId === itemId);
+          if (input) {
+            overrideDemand += calcRate(input.amount, recipe.craftingTime) * fc;
+          }
+        }
+      });
+    }
+
+    feedersAdded.push({
+      feederRecipe: feeder,
+      overrideRecipeId,
+      overrideDemand,
+    });
+  }
+
+  if (feedersAdded.length === 0) return false;
+
+  const originalSCCRecipes = new Set(scc.recipes);
+  const originalExternalInputs = new Set(scc.externalInputs);
+  const addedRecipeIds: RecipeId[] = [];
+  const addedItemIds: ItemId[] = [];
+  const addedConsumptionEdges: { itemId: ItemId; recipeId: RecipeId }[] = [];
+
+  const rollback = () => {
+    for (const id of scc.recipes) {
+      if (!originalSCCRecipes.has(id)) scc.recipes.delete(id);
+    }
+    for (const id of scc.externalInputs) {
+      if (!originalExternalInputs.has(id)) scc.externalInputs.delete(id);
+    }
+    for (const id of addedRecipeIds) {
+      graph.recipeNodes.delete(id);
+      graph.recipeInputs.delete(id);
+      graph.recipeOutputs.delete(id);
+      recipeFacilityCounts.delete(id);
+    }
+    for (const id of addedItemIds) {
+      graph.itemNodes.delete(id);
+      graph.rawMaterials.delete(id);
+    }
+    for (const { itemId, recipeId } of addedConsumptionEdges) {
+      graph.itemConsumedBy.get(itemId)?.delete(recipeId);
+    }
+  };
+
+  for (const { feederRecipe } of feedersAdded) {
+    const facility = maps.facilityMap.get(feederRecipe.facilityId);
+    if (!facility) continue;
+
+    if (!graph.recipeNodes.has(feederRecipe.id)) {
+      graph.recipeNodes.set(feederRecipe.id, {
+        recipeId: feederRecipe.id,
+        recipe: feederRecipe,
+        facility,
+      });
+      graph.recipeInputs.set(feederRecipe.id, new Set());
+      graph.recipeOutputs.set(feederRecipe.id, new Set());
+      addedRecipeIds.push(feederRecipe.id);
+    }
+
+    for (const out of feederRecipe.outputs) {
+      graph.recipeOutputs.get(feederRecipe.id)!.add(out.itemId);
+      if (!graph.itemNodes.has(out.itemId)) {
+        const outItem = maps.itemMap.get(out.itemId);
+        if (outItem) {
+          graph.itemNodes.set(out.itemId, {
+            itemId: out.itemId,
+            item: outItem,
+            isRawMaterial: false,
+          });
+          addedItemIds.push(out.itemId);
+        }
+      }
+    }
+
+    for (const inp of feederRecipe.inputs) {
+      graph.recipeInputs.get(feederRecipe.id)!.add(inp.itemId);
+      if (!graph.itemConsumedBy.has(inp.itemId)) {
+        graph.itemConsumedBy.set(inp.itemId, new Set());
+      }
+      graph.itemConsumedBy.get(inp.itemId)!.add(feederRecipe.id);
+      addedConsumptionEdges.push({
+        itemId: inp.itemId,
+        recipeId: feederRecipe.id,
+      });
+
+      if (!graph.itemNodes.has(inp.itemId)) {
+        const inpItem = maps.itemMap.get(inp.itemId);
+        if (inpItem) {
+          const isRaw =
+            forcedRawMaterials.has(inp.itemId) ||
+            (manualRawMaterials?.has(inp.itemId) ?? false);
+          graph.itemNodes.set(inp.itemId, {
+            itemId: inp.itemId,
+            item: inpItem,
+            isRawMaterial: isRaw,
+          });
+          if (isRaw) graph.rawMaterials.add(inp.itemId);
+          addedItemIds.push(inp.itemId);
+        }
+      }
+
+      if (!scc.items.has(inp.itemId)) {
+        scc.externalInputs.add(inp.itemId);
+      }
+    }
+
+    scc.recipes.add(feederRecipe.id);
+
+    console.log(
+      `  [SCC_EXTEND] Added feeder recipe ${feederRecipe.id} to SCC ${scc.id}`,
+    );
+  }
+
+  const extItemsList = Array.from(scc.items);
+  const extRecipesList = Array.from(scc.recipes).map(
+    (rid) => maps.recipeMap.get(rid)!,
+  );
+  const n = extItemsList.length;
+  const m = extRecipesList.length;
+
+  const externalDemands = new Map<ItemId, number>();
+  for (const itemId of scc.items) {
+    let demand = 0;
+    const consumers = graph.itemConsumedBy.get(itemId);
+    if (consumers) {
+      consumers.forEach((recipeId) => {
+        if (!scc.recipes.has(recipeId)) {
+          const fc = recipeFacilityCounts.get(recipeId) || 0;
+          const recipe = maps.recipeMap.get(recipeId)!;
+          const input = recipe.inputs.find((i) => i.itemId === itemId);
+          if (input) {
+            demand += calcRate(input.amount, recipe.craftingTime) * fc;
+          }
+        }
+      });
+    }
+    if (graph.targets.has(itemId)) {
+      demand += itemDemands.get(itemId) || 0;
+    }
+    if (demand > 0) externalDemands.set(itemId, demand);
+  }
+
+  const pinnedRecipes = new Map<number, number>();
+  for (const { overrideRecipeId, overrideDemand } of feedersAdded) {
+    const overrideIdx = extRecipesList.findIndex(
+      (r) => r.id === overrideRecipeId,
+    );
+    if (overrideIdx === -1) continue;
+
+    const overrideRecipe = extRecipesList[overrideIdx];
+    const outputItem = overrideRecipe.outputs.find((o) =>
+      scc.items.has(o.itemId),
+    );
+    if (!outputItem) continue;
+
+    const rate = calcRate(outputItem.amount, overrideRecipe.craftingTime);
+    if (rate > 0) {
+      pinnedRecipes.set(overrideIdx, overrideDemand / rate);
+      console.log(
+        `  [SCC_EXTEND] Pinning override recipe ${overrideRecipe.id} (index ${overrideIdx}) to ${(overrideDemand / rate).toFixed(4)} facilities`,
+      );
+    }
+  }
+
+  if (pinnedRecipes.size === 0) {
+    rollback();
+    return false;
+  }
+
+  const freeIndices = Array.from({ length: m }, (_, i) => i).filter(
+    (i) => !pinnedRecipes.has(i),
+  );
+  const freeM = freeIndices.length;
+
+  const extRawRows: SystemRow[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const itemId = extItemsList[i];
+    const row = new Array(freeM).fill(0);
+    const externalDemand = externalDemands.get(itemId) || 0;
+    let rhs = externalDemand;
+
+    for (let j = 0; j < m; j++) {
+      const recipe = extRecipesList[j];
+      const output =
+        recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
+      const input =
+        recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
+      const coeff =
+        calcRate(output, recipe.craftingTime) -
+        calcRate(input, recipe.craftingTime);
+
+      if (pinnedRecipes.has(j)) {
+        rhs -= coeff * pinnedRecipes.get(j)!;
+      } else {
+        const freeIdx = freeIndices.indexOf(j);
+        row[freeIdx] = coeff;
+      }
+    }
+
+    extRawRows.push({ row, rhs, itemId });
+  }
+
+  const extFilteredRows = filterImpossibleDisposalRows(
+    extRawRows,
+    freeM,
+    graph.rawMaterials,
+  );
+  const matrix = extFilteredRows.map((e) => e.row);
+  const constants = extFilteredRows.map((e) => e.rhs);
+  const extEffectiveN = extFilteredRows.length;
+
+  console.log(
+    `  [SCC_EXTEND] Solving extended system: ${extEffectiveN} items × ${freeM} free recipes (${pinnedRecipes.size} pinned, ${m} total)`,
+  );
+
+  const freeSolution = solveOverdetermined(matrix, constants, freeM);
+
+  if (!freeSolution) {
+    console.warn(
+      `  [SCC_EXTEND] Extended system still has no solution for SCC ${scc.id}`,
+    );
+    rollback();
+    return false;
+  }
+
+  console.log(`  [SCC_EXTEND] Solution found:`);
+  for (let j = 0; j < m; j++) {
+    let facilityCount: number;
+    if (pinnedRecipes.has(j)) {
+      facilityCount = pinnedRecipes.get(j)!;
+    } else {
+      const freeIdx = freeIndices.indexOf(j);
+      facilityCount = Math.max(0, freeSolution[freeIdx]);
+    }
+    recipeFacilityCounts.set(extRecipesList[j].id, facilityCount);
+    console.log(
+      `    Recipe ${extRecipesList[j].id}: ${facilityCount.toFixed(4)} facilities${pinnedRecipes.has(j) ? " (pinned)" : ""}`,
+    );
+  }
+
+  // --- Phase 4: Compute deficits ---
+  for (let i = 0; i < n; i++) {
+    const itemId = extItemsList[i];
+    let netProduction = 0;
+
+    for (let j = 0; j < m; j++) {
+      const recipe = extRecipesList[j];
+      const facilityCount = recipeFacilityCounts.get(recipe.id) || 0;
+      const output =
+        recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
+      const input =
+        recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
+      netProduction +=
+        (calcRate(output, recipe.craftingTime) -
+          calcRate(input, recipe.craftingTime)) *
+        facilityCount;
+    }
+
+    const externalDemand = externalDemands.get(itemId) || 0;
+    const deficit = externalDemand - netProduction;
+
+    if (deficit > 1e-9) {
+      itemDemands.set(itemId, Math.max(itemDemands.get(itemId) || 0, deficit));
+      console.log(
+        `  [SCC_EXTEND] Item ${itemId} has deficit of ${deficit.toFixed(4)}/min — propagated`,
+      );
+    }
+  }
+
+  // Check: did the extension actually resolve the target demand?
+  for (let i = 0; i < n; i++) {
+    const itemId = extItemsList[i];
+    if (!graph.targets.has(itemId)) continue;
+
+    let targetNetProduction = 0;
+    for (let j = 0; j < m; j++) {
+      const recipe = extRecipesList[j];
+      const facilityCount = recipeFacilityCounts.get(recipe.id) || 0;
+      const output =
+        recipe.outputs.find((o) => o.itemId === itemId)?.amount || 0;
+      const input =
+        recipe.inputs.find((inp) => inp.itemId === itemId)?.amount || 0;
+      targetNetProduction +=
+        (calcRate(output, recipe.craftingTime) -
+          calcRate(input, recipe.craftingTime)) *
+        facilityCount;
+    }
+
+    const externalDemand = externalDemands.get(itemId) || 0;
+    if (externalDemand - targetNetProduction > 1e-9) {
+      console.warn(
+        `  [SCC_EXTEND] Target ${itemId} has unresolved deficit of ${(externalDemand - targetNetProduction).toFixed(4)}/min — extension failed`,
+      );
+      rollback();
+      return false;
+    }
+  }
+
+  // --- Phase 5: Propagate demands to external inputs ---
+  scc.externalInputs.forEach((inputItemId) => {
+    let totalConsumption = 0;
+    scc.recipes.forEach((recipeId) => {
+      const recipe = maps.recipeMap.get(recipeId)!;
+      const facilityCount = recipeFacilityCounts.get(recipeId) || 0;
+      const input = recipe.inputs.find((i) => i.itemId === inputItemId);
+      if (input) {
+        totalConsumption +=
+          calcRate(input.amount, recipe.craftingTime) * facilityCount;
+      }
+    });
+
+    if (totalConsumption > 0) {
+      itemDemands.set(
+        inputItemId,
+        (itemDemands.get(inputItemId) || 0) + totalConsumption,
+      );
+      console.log(
+        `  [SCC_EXTEND] External input ${inputItemId} demand: ${totalConsumption.toFixed(4)}/min`,
+      );
+    }
+  });
+
+  resolvedSCCIds?.add(scc.id);
+
+  return true;
+}

--- a/src/lib/graph-builder.ts
+++ b/src/lib/graph-builder.ts
@@ -1,0 +1,373 @@
+import type { Recipe, ItemId, RecipeId } from "@/types";
+import { forcedRawMaterials } from "@/data";
+import type {
+  ProductionMaps,
+  BipartiteGraph,
+  SCCInfo,
+  CondensedNode,
+  RecipeChoice,
+  BuildGraphResult,
+} from "./calculator-types";
+
+const isDismantleRecipe = (r: Recipe): boolean =>
+  r.inputs.some((i) => i.itemId.startsWith("item_fbottle_"));
+
+const selectRecipe = (recipes: Recipe[], visitedPath: Set<ItemId>): Recipe => {
+  const nonDismantle = recipes.filter((r) => !isDismantleRecipe(r));
+  const pool = nonDismantle.length > 0 ? nonDismantle : recipes;
+
+  const singleOutput = pool.filter((r) => r.outputs.length === 1);
+
+  if (singleOutput.length > 0) {
+    if (visitedPath.size > 0) {
+      const nonCircular = singleOutput.filter(
+        (r) => !r.inputs.some((input) => visitedPath.has(input.itemId)),
+      );
+      if (nonCircular.length > 0) return nonCircular[0];
+    }
+    return singleOutput[0];
+  }
+
+  if (visitedPath.size > 0) {
+    const nonCircular = pool.filter(
+      (r) => !r.inputs.some((input) => visitedPath.has(input.itemId)),
+    );
+    if (nonCircular.length > 0) return nonCircular[0];
+  }
+
+  return pool[0];
+};
+
+export { selectRecipe, isDismantleRecipe };
+
+const getOrThrow = <K, V>(map: Map<K, V>, key: K, type: string): V => {
+  const value = map.get(key);
+  if (!value) throw new Error(`${type} not found: ${key}`);
+  return value;
+};
+
+export { getOrThrow };
+
+export function buildBipartiteGraph(
+  targets: Array<{ itemId: ItemId; rate: number }>,
+  maps: ProductionMaps,
+  recipeOverrides?: Map<ItemId, RecipeId>,
+  manualRawMaterials?: Set<ItemId>,
+  recipeConstraints?: Map<ItemId, Set<RecipeId>>,
+): BuildGraphResult {
+  const graph: BipartiteGraph = {
+    itemNodes: new Map(),
+    recipeNodes: new Map(),
+    itemConsumedBy: new Map(),
+    recipeInputs: new Map(),
+    recipeOutputs: new Map(),
+    targets: new Set(targets.map((t) => t.itemId)),
+    rawMaterials: new Set(),
+  };
+
+  const recipeChoices = new Map<ItemId, RecipeChoice>();
+  const visitedItems = new Set<ItemId>();
+
+  function traverse(itemId: ItemId, visitedPath: Set<ItemId>) {
+    if (visitedItems.has(itemId)) return;
+    visitedItems.add(itemId);
+
+    const item = getOrThrow(maps.itemMap, itemId, "Item");
+
+    const isRaw =
+      forcedRawMaterials.has(itemId) ||
+      (manualRawMaterials?.has(itemId) ?? false);
+
+    graph.itemNodes.set(itemId, { itemId, item, isRawMaterial: isRaw });
+
+    if (isRaw) {
+      graph.rawMaterials.add(itemId);
+      return;
+    }
+
+    let availableRecipes = Array.from(maps.recipeMap.values()).filter((r) =>
+      r.outputs.some((o) => o.itemId === itemId),
+    );
+
+    const excludedRecipes = recipeConstraints?.get(itemId);
+    if (excludedRecipes && excludedRecipes.size > 0) {
+      availableRecipes = availableRecipes.filter(
+        (r) => !excludedRecipes.has(r.id),
+      );
+    }
+
+    if (availableRecipes.length === 0) {
+      graph.itemNodes.get(itemId)!.isRawMaterial = true;
+      graph.rawMaterials.add(itemId);
+      return;
+    }
+
+    const recipeIds = availableRecipes.map((r) => r.id);
+    let currentIndex = 0;
+
+    let selectedRecipe: Recipe;
+    if (recipeOverrides?.has(itemId)) {
+      selectedRecipe = getOrThrow(
+        maps.recipeMap,
+        recipeOverrides.get(itemId)!,
+        "Override recipe",
+      );
+      currentIndex = recipeIds.indexOf(selectedRecipe.id);
+      if (currentIndex === -1) currentIndex = 0;
+    } else {
+      selectedRecipe = selectRecipe(availableRecipes, visitedPath);
+      currentIndex = recipeIds.indexOf(selectedRecipe.id);
+    }
+
+    if (availableRecipes.length > 1) {
+      recipeChoices.set(itemId, {
+        itemId,
+        availableRecipes: recipeIds,
+        currentIndex,
+      });
+    }
+
+    const facility = getOrThrow(
+      maps.facilityMap,
+      selectedRecipe.facilityId,
+      "Facility",
+    );
+
+    if (!graph.recipeNodes.has(selectedRecipe.id)) {
+      graph.recipeNodes.set(selectedRecipe.id, {
+        recipeId: selectedRecipe.id,
+        recipe: selectedRecipe,
+        facility,
+      });
+      graph.recipeInputs.set(selectedRecipe.id, new Set());
+      graph.recipeOutputs.set(selectedRecipe.id, new Set());
+    }
+
+    selectedRecipe.outputs.forEach((out) => {
+      graph.recipeOutputs.get(selectedRecipe.id)!.add(out.itemId);
+
+      if (!graph.itemNodes.has(out.itemId)) {
+        const outItem = maps.itemMap.get(out.itemId);
+        if (outItem) {
+          graph.itemNodes.set(out.itemId, {
+            itemId: out.itemId,
+            item: outItem,
+            isRawMaterial: false,
+          });
+        }
+      }
+    });
+
+    const newVisitedPath = new Set(visitedPath);
+    newVisitedPath.add(itemId);
+
+    selectedRecipe.inputs.forEach((input) => {
+      graph.recipeInputs.get(selectedRecipe.id)!.add(input.itemId);
+
+      if (!graph.itemConsumedBy.has(input.itemId)) {
+        graph.itemConsumedBy.set(input.itemId, new Set());
+      }
+      graph.itemConsumedBy.get(input.itemId)!.add(selectedRecipe.id);
+
+      traverse(input.itemId, newVisitedPath);
+    });
+  }
+
+  targets.forEach(({ itemId }) => traverse(itemId, new Set()));
+
+  return { graph, recipeChoices };
+}
+
+export function detectSCCs(graph: BipartiteGraph): SCCInfo[] {
+  const sccs: SCCInfo[] = [];
+  const indices = new Map<string, number>();
+  const lowlinks = new Map<string, number>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+  let index = 0;
+
+  function strongConnect(nodeId: string, nodeType: "item" | "recipe") {
+    indices.set(nodeId, index);
+    lowlinks.set(nodeId, index);
+    index++;
+    stack.push(nodeId);
+    onStack.add(nodeId);
+
+    const successors: Array<[string, "item" | "recipe"]> = [];
+
+    if (nodeType === "item") {
+      const consumerRecipes = graph.itemConsumedBy.get(nodeId as ItemId);
+      if (consumerRecipes) {
+        consumerRecipes.forEach((recipeId) => {
+          successors.push([recipeId, "recipe"]);
+        });
+      }
+    } else {
+      const outputs = graph.recipeOutputs.get(nodeId as RecipeId);
+      if (outputs) {
+        outputs.forEach((itemId) => {
+          successors.push([itemId, "item"]);
+        });
+      }
+    }
+
+    successors.forEach(([succId, succType]) => {
+      if (!indices.has(succId)) {
+        strongConnect(succId, succType);
+        lowlinks.set(
+          nodeId,
+          Math.min(lowlinks.get(nodeId)!, lowlinks.get(succId)!),
+        );
+      } else if (onStack.has(succId)) {
+        lowlinks.set(
+          nodeId,
+          Math.min(lowlinks.get(nodeId)!, indices.get(succId)!),
+        );
+      }
+    });
+
+    if (lowlinks.get(nodeId) === indices.get(nodeId)) {
+      const sccItems = new Set<ItemId>();
+      const sccRecipes = new Set<RecipeId>();
+
+      let w: string;
+      do {
+        w = stack.pop()!;
+        onStack.delete(w);
+
+        if (graph.itemNodes.has(w as ItemId)) {
+          sccItems.add(w as ItemId);
+        } else {
+          sccRecipes.add(w as RecipeId);
+        }
+      } while (w !== nodeId);
+
+      if (sccItems.size + sccRecipes.size > 1) {
+        const externalInputs = new Set<ItemId>();
+
+        sccRecipes.forEach((recipeId) => {
+          const inputs = graph.recipeInputs.get(recipeId) || new Set();
+          inputs.forEach((inputItemId) => {
+            if (!sccItems.has(inputItemId)) {
+              externalInputs.add(inputItemId);
+            }
+          });
+        });
+
+        const sccInfo: SCCInfo = {
+          id: `scc-${Array.from(sccItems).sort().join("-")}`,
+          items: sccItems,
+          recipes: sccRecipes,
+          externalInputs,
+        };
+
+        console.log(`[SCC] Detected cycle: ${sccInfo.id}`);
+        console.log(`  Items (${sccItems.size}):`, Array.from(sccItems));
+        console.log(`  Recipes (${sccRecipes.size}):`, Array.from(sccRecipes));
+        console.log(
+          `  External inputs (${externalInputs.size}):`,
+          Array.from(externalInputs),
+        );
+
+        sccs.push(sccInfo);
+      }
+    }
+  }
+
+  graph.itemNodes.forEach((_, itemId) => {
+    if (!indices.has(itemId)) {
+      strongConnect(itemId, "item");
+    }
+  });
+
+  console.log(`[SCC] Total SCCs detected: ${sccs.length}`);
+  return sccs;
+}
+
+export function buildCondensedDAGAndSort(
+  graph: BipartiteGraph,
+  sccs: SCCInfo[],
+): CondensedNode[] {
+  const nodeToSCC = new Map<string, string>();
+
+  sccs.forEach((scc) => {
+    scc.items.forEach((itemId) => nodeToSCC.set(itemId, scc.id));
+    scc.recipes.forEach((recipeId) => nodeToSCC.set(recipeId, scc.id));
+  });
+
+  const condensedNodes = new Map<string, CondensedNode>();
+  const condensedEdges = new Map<string, Set<string>>();
+
+  sccs.forEach((scc) => {
+    condensedNodes.set(scc.id, { type: "scc", scc });
+    condensedEdges.set(scc.id, new Set());
+  });
+
+  graph.itemNodes.forEach((_, itemId) => {
+    if (!nodeToSCC.has(itemId)) {
+      condensedNodes.set(itemId, { type: "item", itemId });
+      condensedEdges.set(itemId, new Set());
+    }
+  });
+
+  graph.recipeNodes.forEach((_, recipeId) => {
+    if (!nodeToSCC.has(recipeId)) {
+      condensedNodes.set(recipeId, { type: "recipe", recipeId });
+      condensedEdges.set(recipeId, new Set());
+    }
+  });
+
+  const addEdge = (fromId: string, toId: string) => {
+    const fromCondensed = nodeToSCC.get(fromId) || fromId;
+    const toCondensed = nodeToSCC.get(toId) || toId;
+
+    if (fromCondensed !== toCondensed) {
+      condensedEdges.get(fromCondensed)!.add(toCondensed);
+    }
+  };
+
+  graph.itemConsumedBy.forEach((recipeIds, itemId) => {
+    recipeIds.forEach((recipeId) => {
+      addEdge(itemId, recipeId);
+    });
+  });
+
+  graph.recipeOutputs.forEach((itemIds, recipeId) => {
+    itemIds.forEach((itemId) => {
+      addEdge(recipeId, itemId);
+    });
+  });
+
+  const inDegree = new Map<string, number>();
+  condensedNodes.forEach((_, nodeId) => {
+    inDegree.set(nodeId, 0);
+  });
+
+  condensedEdges.forEach((targets) => {
+    targets.forEach((target) => {
+      inDegree.set(target, (inDegree.get(target) || 0) + 1);
+    });
+  });
+
+  const queue: string[] = [];
+  inDegree.forEach((degree, nodeId) => {
+    if (degree === 0) queue.push(nodeId);
+  });
+
+  const topoOrder: CondensedNode[] = [];
+
+  while (queue.length > 0) {
+    const nodeId = queue.shift()!;
+    topoOrder.push(condensedNodes.get(nodeId)!);
+
+    condensedEdges.get(nodeId)!.forEach((target) => {
+      const newDegree = inDegree.get(target)! - 1;
+      inDegree.set(target, newDegree);
+      if (newDegree === 0) {
+        queue.push(target);
+      }
+    });
+  }
+
+  return topoOrder;
+}

--- a/src/tests/lib/calculator.test.ts
+++ b/src/tests/lib/calculator.test.ts
@@ -1072,4 +1072,30 @@ describe("Real 1.2 data regression", () => {
       expect(mossGrinder.facilityCount).toBeGreaterThan(0);
     }
   });
+
+  test("copper_enr + xiranite_poly multi-target does not inflate water consumption", () => {
+    const plan = calculateProductionPlan(
+      [
+        { itemId: ItemId.ITEM_COPPER_ENR, rate: 5 },
+        { itemId: ItemId.ITEM_XIRANITE_POLY, rate: 5 },
+      ],
+      items,
+      recipes,
+      facilities,
+    );
+    expect(plan.invalidCycles).toEqual([]);
+
+    const water = plan.nodes.get(ItemId.ITEM_LIQUID_WATER);
+    expect(water?.type).toBe("item");
+    // Pre-fix multi-target blowup produced 60/min; combined demand with the
+    // byproduct-recovery recipe preserved must stay sub-additive vs the two
+    // single-target plans (A=40, B=17, sum=57).
+    if (water?.type === "item") {
+      expect(water.productionRate).toBeLessThanOrEqual(57);
+    }
+
+    expect(
+      plan.nodes.has(RecipeId.LIQUID_PURIFIER_XIRANITE_POLY_1),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
fix #59 

## Problem                                                                                                                        

Setting 1 `item_xiranite_enr_powder` as a production target produced a broken plan: the entire upstream chain (`plant_moss`, `carbon_enr`, `xiranite_powder`, etc.) rendered with `facilityCount=0` in the UI, even though those recipes are legitimate upstream producers.                                                                                                                     

Root cause: the SCC solver failed on iteration 1, triggering the backtrack loop. By iteration 7, a no-pinned branch fed an     
  overdetermined system into `solveLinearSystem` (which assumes a square matrix), producing NaN and zeroing all facility counts.

Inside the Xiranite SCC, after pinning the external-output recipes, one equation became:                                       
  
liquid_xiranite_lowpoly:  0*r0 + 0*r1 + 0*r4 = 90                                                                              
                                                            
RHS=90 is surplus lowpoly produced by the pinned recipes. No free recipe inside the SCC consumes lowpoly — the real consumer is a downstream disposal recipe (liquid_xiranite_lowpoly is in forcedDisposalItems). The solver enforced mass balance on this item anyway and reported "no solution".                                                                                        

## Fix

Added filterImpossibleDisposalRows (in `src/lib/calculator.ts`), invoked in all three Phase-3 matrix-building sites (pinned branch, no-pinned branch, tryExtendSCCWithFeeders). It drops two categories of rows before solving:
1. Infeasible: `forcedDisposalItems` member with all-zero LHS and non-zero RHS. Surplus is handled later by injectDisposalRecipes, so the equation is slack.
2. Slack (only while rows.length > numVars): forced-raw-material rows first (external supply always absorbs deficit), then forced-disposal rows with rhs <= 0 (surplus already absorbable). Keeps the system determined.                                   
   
sewage in the Xircon SCC has non-zero coefficients (consumed by pool_liquid_xiranite_poly_1), so it fails condition 1 and is  retained — Xircon regression is unaffected.