### PR TITLE
Fix: Orphaned disposal sink for terminal recipes with disposal byproducts + per-output source handles

### DIFF
--- a/src/components/flow/flow-utils.ts
+++ b/src/components/flow/flow-utils.ts
@@ -69,6 +69,7 @@ export function createEdge(
     id,
     source,
     target,
+    sourceHandle: item?.id,
     type: direction === "backward" ? "backwardEdge" : "simplebezier",
     label: `${flowRate.toFixed(2)} /min\n${transportStr}`,
     data: {

--- a/src/components/mappers/flow-assertions.ts
+++ b/src/components/mappers/flow-assertions.ts
@@ -1,0 +1,45 @@
+import type { Node, Edge } from "@xyflow/react";
+
+/**
+ * Warns when edges reference missing node ids or nodes have no incident edges.
+ * Dev-only — mapper bugs often surface as dangling edges or orphaned sinks
+ * that the layout silently accepts; surfacing them in console catches
+ * regressions before they reach the user.
+ */
+export function assertFlowIntegrity(
+  mapperName: string,
+  nodes: Node[],
+  edges: Edge[],
+): void {
+  if (import.meta.env?.PROD) return;
+
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const missing: { edgeId: string; side: "source" | "target"; id: string }[] = [];
+  const referenced = new Set<string>();
+
+  for (const edge of edges) {
+    if (!nodeIds.has(edge.source)) {
+      missing.push({ edgeId: edge.id, side: "source", id: edge.source });
+    }
+    if (!nodeIds.has(edge.target)) {
+      missing.push({ edgeId: edge.id, side: "target", id: edge.target });
+    }
+    referenced.add(edge.source);
+    referenced.add(edge.target);
+  }
+
+  const isolated = nodes.filter((n) => !referenced.has(n.id));
+
+  if (missing.length > 0) {
+    console.warn(
+      `[${mapperName}] ${missing.length} edge endpoint(s) reference missing nodes:`,
+      missing,
+    );
+  }
+  if (isolated.length > 0 && nodes.length > 1) {
+    console.warn(
+      `[${mapperName}] ${isolated.length} node(s) have no incident edges:`,
+      isolated.map((n) => n.id),
+    );
+  }
+}

--- a/src/components/mappers/merged-mapper.ts
+++ b/src/components/mappers/merged-mapper.ts
@@ -19,6 +19,7 @@ import {
 import { createTargetSinkId, createRawMaterialId } from "@/lib/node-keys";
 import { calcRate } from "@/lib/utils";
 import { getRecipeOutputItemId, getRecipeInputItemId, getItemProducers, isRecipeTerminal, computeGreedyAllocation } from "@/lib/plan-helpers";
+import { assertFlowIntegrity } from "./flow-assertions";
 
 /**
  * Maps a ProductionDependencyGraph to React Flow nodes and edges in merged mode.
@@ -472,12 +473,11 @@ export function mapPlanToFlowMerged(
     }
   });
 
-  return {
-    nodes: [...flowNodes, ...targetSinkNodes, ...disposalSinkNodes] as (
-      | FlowProductionNode
-      | FlowTargetNode
-      | FlowDisposalNode
-    )[],
-    edges: flowEdges,
-  };
+  const allNodes = [...flowNodes, ...targetSinkNodes, ...disposalSinkNodes] as (
+    | FlowProductionNode
+    | FlowTargetNode
+    | FlowDisposalNode
+  )[];
+  assertFlowIntegrity("merged-mapper", allNodes, flowEdges);
+  return { nodes: allNodes, edges: flowEdges };
 }

--- a/src/components/mappers/separated-mapper.ts
+++ b/src/components/mappers/separated-mapper.ts
@@ -18,6 +18,7 @@ import {
 } from "../flow/flow-utils";
 import { createTargetSinkId, createPickupPointId } from "@/lib/node-keys";
 import { getRecipeOutputItemId, getRecipeInputItemId, getItemProducers, isRecipeTerminal } from "@/lib/plan-helpers";
+import { assertFlowIntegrity } from "./flow-assertions";
 import {
   calcRate,
   getOutputAmount,
@@ -828,8 +829,7 @@ export function mapPlanToFlowSeparated(
     }
   });
 
-  return {
-    nodes: [...flowNodes, ...targetSinkNodes, ...disposalSinkNodes],
-    edges: edges,
-  };
+  const allNodes = [...flowNodes, ...targetSinkNodes, ...disposalSinkNodes];
+  assertFlowIntegrity("separated-mapper", allNodes, edges);
+  return { nodes: allNodes, edges };
 }

--- a/src/components/nodes/CustomProductionNode.tsx
+++ b/src/components/nodes/CustomProductionNode.tsx
@@ -85,6 +85,8 @@ export default function CustomProductionNode({
         .filter((b) => b.item != null)
     : [];
 
+  const outputHandleIds = [node.item.id, ...byproducts.map((b) => b.item!.id)];
+
   // Adjust border/rate colors based on node type for better visual distinction
   let borderClasses = "border-2";
   let bgClasses = "";
@@ -290,13 +292,17 @@ export default function CustomProductionNode({
               </div>
             )}
           </CardContent>
-          <Handle
-            type="source"
-            position={Position.Right}
-            id="right"
-            isConnectable={false}
-            className="w-3! h-3!"
-          />
+          {outputHandleIds.map((outId, i) => (
+            <Handle
+              key={outId}
+              type="source"
+              position={Position.Right}
+              id={outId}
+              isConnectable={false}
+              className="w-3! h-3!"
+              style={{ top: `${((i + 1) / (outputHandleIds.length + 1)) * 100}%` }}
+            />
+          ))}
         </Card>
       </TooltipTrigger>
       {/* Tooltip content with detailed information */}

--- a/src/lib/plan-helpers.ts
+++ b/src/lib/plan-helpers.ts
@@ -82,18 +82,19 @@ export function isRecipeTerminal(
   });
   if (primaryIsConsumed) return false;
 
-  // No secondary output should be consumed by a non-disposal recipe
+  // No secondary output should be consumed by any recipe (including disposal).
+  // Disposal-consumed secondaries must keep the recipe node visible so the
+  // disposal edge has a source — otherwise the disposal sink ends up orphaned.
   const allOutputIds = getRecipeOutputItemIds(plan, recipeId);
-  const hasActiveSecondaryOutput = allOutputIds.some((outId) => {
+  const hasSecondaryConsumer = allOutputIds.some((outId) => {
     if (outId === primaryOutputId) return false;
     return plan.edges.some((e) => {
       if (e.from !== outId) return false;
-      const consumer = plan.nodes.get(e.to);
-      return consumer?.type === "recipe" && !consumer.isDisposal;
+      return plan.nodes.get(e.to)?.type === "recipe";
     });
   });
 
-  return !hasActiveSecondaryOutput;
+  return !hasSecondaryConsumer;
 }
 
 /**

--- a/src/tests/lib/flow-integrity.test.ts
+++ b/src/tests/lib/flow-integrity.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect, beforeAll } from "vitest";
+import { calculateProductionPlan } from "@/lib/calculator";
+import { mapPlanToFlowMerged } from "@/components/mappers/merged-mapper";
+import { mapPlanToFlowSeparated } from "@/components/mappers/separated-mapper";
+import { items, recipes, facilities } from "@/data";
+import type { ItemId, ProductionDependencyGraph } from "@/types";
+import type { Edge, Node } from "@xyflow/react";
+
+function checkIntegrity(nodes: Node[], edges: Edge[]) {
+  const ids = new Set(nodes.map((n) => n.id));
+  const dangling: string[] = [];
+  const referenced = new Set<string>();
+  for (const e of edges) {
+    if (!ids.has(e.source)) dangling.push(`edge ${e.id} source ${e.source} missing`);
+    if (!ids.has(e.target)) dangling.push(`edge ${e.id} target ${e.target} missing`);
+    referenced.add(e.source);
+    referenced.add(e.target);
+  }
+  const isolated = nodes.filter((n) => !referenced.has(n.id)).map((n) => n.id);
+  return { dangling, isolated };
+}
+
+const cases: { name: string; targetId: ItemId; rate: number }[] = [
+  { name: "copper_nugget with sewage byproduct", targetId: "item_copper_nugget" as ItemId, rate: 6 },
+  { name: "iron_nugget", targetId: "item_iron_nugget" as ItemId, rate: 10 },
+  { name: "xiranite_poly", targetId: "item_xiranite_poly" as ItemId, rate: 5 },
+];
+
+describe("flow mapper integrity", () => {
+  const plans = new Map<string, { plan: ProductionDependencyGraph; targetRates: Map<ItemId, number> }>();
+
+  beforeAll(() => {
+    for (const c of cases) {
+      const plan = calculateProductionPlan(
+        [{ itemId: c.targetId, rate: c.rate }],
+        items,
+        recipes,
+        facilities,
+      );
+      plans.set(c.name, { plan, targetRates: new Map([[c.targetId, c.rate]]) });
+    }
+  });
+
+  for (const c of cases) {
+    test(`${c.name}: merged has no dangling edges or isolated nodes`, () => {
+      const { plan, targetRates } = plans.get(c.name)!;
+      const flow = mapPlanToFlowMerged(plan, items, facilities, targetRates);
+      const { dangling, isolated } = checkIntegrity(flow.nodes, flow.edges);
+      expect(dangling).toEqual([]);
+      expect(isolated).toEqual([]);
+    });
+
+    test(`${c.name}: separated has no dangling edges or isolated nodes`, () => {
+      const { plan, targetRates } = plans.get(c.name)!;
+      const flow = mapPlanToFlowSeparated(plan, items, facilities, targetRates);
+      const { dangling, isolated } = checkIntegrity(flow.nodes, flow.edges);
+      expect(dangling).toEqual([]);
+      expect(isolated).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Fix `isRecipeTerminal` treating a recipe as terminal when its byproduct is only consumed by a disposal recipe. When the primary output was a target item (e.g. `item_copper_nugget` with rate 6), the recipe node was skipped during flow node creation, leaving the disposal sink dangling from a non-existent source and raw material edges routing directly to the target sink — which manifested as overlapping nodes in the initial layout.
- Add a dev-only `assertFlowIntegrity` helper invoked at the end of both mappers. It warns when edges reference missing node ids or when nodes end up with no incident edges, catching this class of regression immediately instead of leaving it for a user to spot in the layout.
- Add `src/tests/lib/flow-integrity.test.ts` with representative cases (byproduct-to-disposal target, simple terminal target, SCC-participating target) that run both merged and separated mappers against the real game data and assert no dangling edges or isolated nodes.
- Give each recipe output its own source handle on `CustomProductionNode`, distributed evenly along the right edge of the node. The `createEdge` helper now automatically derives `sourceHandle` from the edge's `item.id`, so every mapper call site benefits without signature churn. Multi-output recipes (e.g. furnace producing copper_nugget + liquid_sewage) now have visually distinct exits for each output item.
