### PR TITLE
Fix: SCC solver double-counts target demand for items with external consumers

### DIFF
--- a/src/lib/flow-solver.ts
+++ b/src/lib/flow-solver.ts
@@ -78,6 +78,7 @@ export function calculateFlows(
         graph,
         itemDemands,
         recipeFacilityCounts,
+        targetRates,
         maps,
         recipeOverrides,
         resolvedSCCIds,
@@ -145,6 +146,7 @@ function solveSCCFlow(
   graph: BipartiteGraph,
   itemDemands: Map<ItemId, number>,
   recipeFacilityCounts: Map<RecipeId, number>,
+  targetRates: Map<ItemId, number>,
   maps: ProductionMaps,
   recipeOverrides?: Map<ItemId, RecipeId>,
   resolvedSCCIds?: Set<string>,
@@ -190,7 +192,11 @@ function solveSCCFlow(
     }
 
     if (graph.targets.has(itemId)) {
-      const targetDemand = itemDemands.get(itemId) || 0;
+      // Use raw target rate, NOT itemDemands — itemDemands has already
+      // accumulated input demand from external consumer recipes processed
+      // earlier in reverse-topo order (those are added separately above
+      // via `consumers`), so reading from itemDemands double-counts.
+      const targetDemand = targetRates.get(itemId) || 0;
       demand += targetDemand;
       console.log(
         `    Item ${itemId} is target with demand: ${targetDemand.toFixed(4)}`,
@@ -241,6 +247,7 @@ function solveSCCFlow(
       graph,
       itemDemands,
       recipeFacilityCounts,
+      targetRates,
       maps,
       recipeOverrides,
       resolvedSCCIds,
@@ -349,6 +356,7 @@ function solveSCCFlow(
         graph,
         itemDemands,
         recipeFacilityCounts,
+        targetRates,
         maps,
         recipeOverrides,
         resolvedSCCIds,
@@ -426,6 +434,7 @@ function solveSCCFlow(
         graph,
         itemDemands,
         recipeFacilityCounts,
+        targetRates,
         maps,
         recipeOverrides,
         resolvedSCCIds,
@@ -508,6 +517,7 @@ function tryExtendSCCWithFeeders(
   graph: BipartiteGraph,
   itemDemands: Map<ItemId, number>,
   recipeFacilityCounts: Map<RecipeId, number>,
+  targetRates: Map<ItemId, number>,
   maps: ProductionMaps,
   recipeOverrides?: Map<ItemId, RecipeId>,
   resolvedSCCIds?: Set<string>,
@@ -541,7 +551,7 @@ function tryExtendSCCWithFeeders(
 
     let overrideDemand = 0;
     if (graph.targets.has(itemId)) {
-      overrideDemand += itemDemands.get(itemId) || 0;
+      overrideDemand += targetRates.get(itemId) || 0;
     }
     const consumers = graph.itemConsumedBy.get(itemId);
     if (consumers) {
@@ -687,7 +697,7 @@ function tryExtendSCCWithFeeders(
       });
     }
     if (graph.targets.has(itemId)) {
-      demand += itemDemands.get(itemId) || 0;
+      demand += targetRates.get(itemId) || 0;
     }
     if (demand > 0) externalDemands.set(itemId, demand);
   }

--- a/src/tests/lib/calculator.test.ts
+++ b/src/tests/lib/calculator.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { calculateProductionPlan } from "@/lib/calculator";
+import { calcRate } from "@/lib/utils";
 import { items } from "@/data/items";
 import { recipes } from "@/data/recipes";
 import { facilities } from "@/data/facilities";
@@ -1097,5 +1098,58 @@ describe("Real 1.2 data regression", () => {
     expect(
       plan.nodes.has(RecipeId.LIQUID_PURIFIER_XIRANITE_POLY_1),
     ).toBe(true);
+  });
+});
+
+describe("Issue #68 — Xiranite over-production", () => {
+  test("Xiranite powder production matches summed consumer demand", () => {
+    const targets = [
+      { itemId: ItemId.ITEM_PROC_BATTERY_5, rate: 11.5 },
+      { itemId: ItemId.ITEM_BOTTLED_REC_HP_5, rate: 1 },
+      { itemId: ItemId.ITEM_EQUIP_SCRIPT_4_2, rate: 1 },
+      { itemId: ItemId.ITEM_COPPER_ENR_CMPT, rate: 2 },
+      { itemId: ItemId.ITEM_XIRANITE_ENR_POWDER, rate: 3 },
+      { itemId: ItemId.ITEM_EQUIP_SCRIPT_4, rate: 1 },
+      { itemId: ItemId.ITEM_EQUIP_SCRIPT_4_1, rate: 1.5 },
+      { itemId: ItemId.ITEM_COPPER_CMPT, rate: 2.5 },
+      { itemId: ItemId.ITEM_COPPER_BOTTLE, rate: 1.25 },
+      { itemId: ItemId.ITEM_XIRANITE_POWDER, rate: 8 },
+      { itemId: ItemId.ITEM_LIQUID_XIRANITE, rate: 1 },
+      { itemId: ItemId.ITEM_LIQUID_XIRANITE_ENR, rate: 1 },
+    ];
+
+    const plan = calculateProductionPlan(
+      targets,
+      items,
+      recipes,
+      facilities,
+    );
+
+    const powder = plan.nodes.get(ItemId.ITEM_XIRANITE_POWDER);
+    expect(powder?.type).toBe("item");
+    if (powder?.type !== "item") return;
+
+    const targetMap = new Map(targets.map((t) => [t.itemId, t.rate]));
+    const targetRate = targetMap.get(ItemId.ITEM_XIRANITE_POWDER) ?? 0;
+
+    // consumer demand = sum over each recipe consuming xiranite powder of
+    //                   calcRate(input.amount, t) * facilityCount
+    let consumerDemand = 0;
+    for (const edge of plan.edges) {
+      if (edge.from !== ItemId.ITEM_XIRANITE_POWDER) continue;
+      const consumer = plan.nodes.get(edge.to);
+      if (consumer?.type !== "recipe") continue;
+      const input = consumer.recipe.inputs.find(
+        (i) => i.itemId === ItemId.ITEM_XIRANITE_POWDER,
+      );
+      if (!input) continue;
+      consumerDemand +=
+        calcRate(input.amount, consumer.recipe.craftingTime) *
+        consumer.facilityCount;
+    }
+
+    const totalDemand = targetRate + consumerDemand;
+
+    expect(powder.productionRate).toBeCloseTo(totalDemand, 3);
   });
 });


### PR DESCRIPTION
`solveSCCFlow` Phase 1 sometimes double-counts the demand for the target item within the SCC, causing the production rate to be larger than the actual demand by ∑(SCC external consumer input).

## Root Cause

`calculateFlows` Reverse topological order processing of the condensed graph:
1. Initialization: `itemDemands.set(itemId, targetRate)` writes the user's target demand.
2. Before SCC, a batch of external consumer recipes have already been processed — each input of these recipes will have `itemDemands[input] += consumption`.
3. Entering SCC `solveSCCFlow` Phase 1:
- (a) Explicitly traversing `itemConsumedBy`, adding the external consumer consumption to `demand`. 
- (b) When targeting an item, additionally `demand += itemDemands.get(itemId)` — at this point, `itemDemands` has already accumulated the external consumer input from step 2. 
4. The same consumer demand is recorded twice.
Issue #68 Case: `item_xiranite_powder` target=8/min, external consumer requires a total of 85/min.
- Incorrect path: itemDemands = 8 + 85 = 93, Phase 1 adds external consumer 85 → total demand within SCC 178 → solver solves for 9.83 forges → 295/min production
- Correct: target 8 + external consumer 85 = 93 → 7 forges → 210/min

fix #68 