### PR TITLE
Fix: Dispose surplus byproducts instead of over-running absorber recipes

### DIFF
--- a/src/lib/flow-solver.ts
+++ b/src/lib/flow-solver.ts
@@ -19,10 +19,16 @@ const isAllZeroRow = (row: number[]): boolean =>
 // Drops equations the SCC solver must not enforce:
 //   1. Unsatisfiable: forced-disposal item with zero LHS and non-zero RHS —
 //      surplus is handled later by injectDisposalRecipes.
-//   2. Slack: forced-disposal-surplus (rhs <= 0) or forced-raw-supply items,
+//   2. Slack: forced-disposal-surplus (rhs < 0) or forced-raw-supply items,
 //      dropped greedily while keeping at least numVars rows so the system
-//      stays determined. Raw-material rows go first (deficit always absorbed
-//      by external supply); disposal rows may still carry balance info.
+//      stays determined. Disposal-surplus rows go first: their RHS encodes
+//      a real surplus from pinned recipes (production > consumption), and
+//      keeping them as equality forces free recipes to over-consume the
+//      byproduct (e.g. POOL_LIQUID_XIRANITE_POLY over-running to absorb
+//      Sewage from the Hetonite chain). Raw-material rows go next (their
+//      deficit is always absorbed by external supply). Disposal rows with
+//      rhs ≈ 0 stay if possible — they may encode a useful balance
+//      constraint (e.g. LOWPOLY tying Pool/Purifier ratio).
 const filterImpossibleDisposalRows = (
   rows: SystemRow[],
   numVars: number,
@@ -34,11 +40,13 @@ const filterImpossibleDisposalRows = (
       !isAllZeroRow(row) ||
       Math.abs(rhs) < 1e-9,
   );
+  const isDisposalSurplus = (r: SystemRow) =>
+    forcedDisposalItems.has(r.itemId) && r.rhs < -1e-9;
   const isRawSlack = (r: SystemRow) => rawMaterials.has(r.itemId);
-  const isDisposalSlack = (r: SystemRow) =>
-    forcedDisposalItems.has(r.itemId) && r.rhs <= 1e-9;
+  const isDisposalBalanced = (r: SystemRow) =>
+    forcedDisposalItems.has(r.itemId) && Math.abs(r.rhs) < 1e-9;
   const remaining = base.slice();
-  for (const isSlack of [isRawSlack, isDisposalSlack]) {
+  for (const isSlack of [isDisposalSurplus, isRawSlack, isDisposalBalanced]) {
     for (let i = remaining.length - 1; i >= 0; i--) {
       if (remaining.length <= numVars) break;
       if (isSlack(remaining[i])) remaining.splice(i, 1);

--- a/src/tests/lib/calculator.test.ts
+++ b/src/tests/lib/calculator.test.ts
@@ -1099,6 +1099,57 @@ describe("Real 1.2 data regression", () => {
       plan.nodes.has(RecipeId.LIQUID_PURIFIER_XIRANITE_POLY_1),
     ).toBe(true);
   });
+
+  test("xiranite_jade_gourd disposes surplus sewage instead of over-running absorber", () => {
+    // Bug regression: previously, 1 Xiranite Jade Gourd at 1/min consumed
+    // 19 Xiranite/min because the Hetonite chain produces 9 Sewage/min as
+    // a byproduct, and the SCC solver routed it all into the Xircon Effluent
+    // pool — over-running the pool from the optimal 4 cycles to 9 cycles
+    // and pulling in 5 extra Liquid Xiranite (= 5 extra Xiranite).
+    //
+    // After the disposal-surplus row prioritization in
+    // `filterImpossibleDisposalRows`, the SCC solver lets the surplus
+    // Sewage be disposed (Sewage is in `forcedDisposalItems`) and balances
+    // Xircon Effluent supply between Pool and Liquid Purifier via the
+    // LOWPOLY constraint, settling at 14 Xiranite/min — the same cost as
+    // producing Heavy Xiranite as a standalone target.
+    const plan = calculateProductionPlan(
+      [{ itemId: ItemId.ITEM_ACTIVITY_XIRANITE_ENR_HULU, rate: 1 }],
+      items,
+      recipes,
+      facilities,
+    );
+
+    const xiranite = plan.nodes.get(ItemId.ITEM_XIRANITE_POWDER);
+    expect(xiranite?.type).toBe("item");
+    if (xiranite?.type === "item") {
+      expect(xiranite.productionRate).toBeCloseTo(14, 1);
+    }
+
+    // Sewage surplus should be disposed (5/min surplus / 30 per facility)
+    const sewageDisposal = plan.nodes.get(
+      RecipeId.FLUID_CONSUME_LIQUID_CLEANER_1_ITEM_LIQUID_SEWAGE,
+    );
+    expect(sewageDisposal).toBeDefined();
+    if (sewageDisposal?.type === "recipe") {
+      expect(sewageDisposal.isDisposal).toBe(true);
+      expect(sewageDisposal.facilityCount).toBeCloseTo(5 / 30, 3);
+    }
+
+    // Liquid Purifier absorbs the LOWPOLY produced by Pool to recover
+    // 1 extra Xircon Effluent, allowing Pool to drop to 4 cycles/min.
+    const purifier = plan.nodes.get(RecipeId.LIQUID_PURIFIER_XIRANITE_POLY_1);
+    expect(purifier?.type).toBe("recipe");
+    if (purifier?.type === "recipe") {
+      expect(purifier.facilityCount).toBeCloseTo(1 / 30, 3);
+    }
+
+    const pool = plan.nodes.get(RecipeId.POOL_LIQUID_XIRANITE_POLY_1);
+    expect(pool?.type).toBe("recipe");
+    if (pool?.type === "recipe") {
+      expect(pool.facilityCount).toBeCloseTo(4 / 30, 3);
+    }
+  });
 });
 
 describe("Issue #68 — Xiranite over-production", () => {


### PR DESCRIPTION
Fixes #72

## Summary

The SCC solver's `filterImpossibleDisposalRows` was dropping rows in array order, sometimes keeping a forced-disposal-surplus row as an equality constraint when it should have been treated as slack. This forced absorber recipes (e.g. `pool_liquid_xiranite_poly_1`) to over-run to consume all upstream byproduct, inflating raw material consumption.

This PR splits the disposal-slack class into `surplus` (`rhs < 0`) and `balanced` (`rhs ≈ 0`) and prioritizes dropping surplus first. Surplus byproducts are then handled by the existing post-solve `injectDisposalRecipes` machinery via the disposal sink, which is far cheaper than forcing an absorber to run.

## Why this is correct

- Disposal-surplus rows with `rhs < 0` represent real surplus from pinned recipes that has nowhere to go inside the SCC. Keeping them as equality forces free recipes to over-consume the byproduct. Dropping them lets the post-solve disposal sink absorb the surplus cheaply.
- Disposal-balanced rows with `rhs ≈ 0` often encode useful in-SCC ratios (e.g. LOWPOLY tying Pool/Purifier). They're now kept whenever possible.
- Phase 4 deficit propagation still triggers correctly when a dropped row turned out to be deficit rather than surplus — the existing safety net is unchanged.
- Disposal facilities exist and have non-zero cost (Liquid Cleaner units), but absorption via Pool costs strictly more (Pool consumes 1 Liquid Xiranite per Sewage absorbed AND produces an Inert byproduct that itself needs disposal). LP-optimal allocation matches the priority-drop heuristic in this regime.

## Evidence

Ran a sweep of 10 candidate scenarios on `master` (baseline) and this branch:

<details>
<summary>Headline metrics</summary>

| # | Scenario | Baseline Xiranite | Fix Xiranite | Savings | Baseline Power | Fix Power | Power Savings |
|---|---|---:|---:|---:|---:|---:|---:|
| 10 | **Heavy Xiranite + Hetonite Component** (`item_equip_script_4_2`) at 1/min each | 120.00 | 42.00 | **−65%** | 2088.33 | 865.00 | **−59%** |
| 05 | **Heavy Xiranite + Hetonite Part** (`item_copper_enr_cmpt`) at 1/min each | 55.00 | 14.00 | **−75%** | 990.56 | 349.44 | **−65%** |
| 02 | **Xiran-Hue Atomizer** at 1/min | 14.00 | 7.00 | **−50%** | 235.78 | 125.22 | **−47%** |
| 01 | **Xiranite Jade Gourd** at 1/min (the bug report) | 19.00 | 14.00 | **−26%** | 308.14 | 227.03 | **−26%** |
| 04 | **Heavy Xiranite + Hetonite** at 1/min each | 19.00 | 14.00 | **−26%** | 281.89 | 200.78 | **−29%** |
| 03 | Hetonite Component alone at 1/min | 28.00 | 28.00 | 0% | 700.56 | 700.56 | 0% |
| 07 | Heavy Xiranite alone at 1/min (control) | 14.00 | 14.00 | 0% | 171.78 | 171.78 | 0% |
| 08 | Issue #68 multi-target (12 items) | 210.00 | 210.00 | 0% | 4248.33 | 4248.33 | 0% |
| 09 | Solid Xircon + Hetonite at 5/min each | 8.00 | 8.00 | 0% | 301.11 | 301.11 | 0% |

Mass-balance integrity: all scenarios OK on the fix branch (no phantom supply); identical to baseline except scenario 06 (Heavy Xiranite + Cuprium Part) which is pre-existing INVALID in both branches and orthogonal to this PR.

</details>

## Tests

- New regression test in `src/tests/lib/calculator.test.ts` (`Real 1.2 data regression > xiranite_jade_gourd disposes surplus sewage instead of over-running absorber`) pinning Pool=4/30, Purifier=1/30, Sewage disposal=5/30, total Xiranite=14/min.
- All 86 existing tests pass on this branch.
