### PR TITLE
Add: Docker self-hosting support (Dockerfile, Compose, GitHub Actions workflow)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+.gitignore
+*.md
+img/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+# Build and push Docker image to GitHub Container Registry on release
+name: Docker Build and Push
+
+on:
+  release:
+    types: [published]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# ── Stage 1: Build ──────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Install pnpm
+RUN npm install -g pnpm@9
+
+# Install dependencies (cached layer)
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Copy source and build
+COPY . .
+RUN pnpm build
+
+# ── Stage 2: Serve ───────────────────────────────────────────────────────────
+FROM nginx:alpine
+
+# Copy built assets to the sub-path the app expects (/endfield-calc/)
+COPY --from=builder /app/dist /usr/share/nginx/html/endfield-calc
+
+# Custom nginx config for SPA routing
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,53 @@ pnpm install
 pnpm run dev
 ```
 
-## Contributing
+### Docker
+
+**Step 1: Build the image via GitHub Actions**
+
+The image is hosted on GitHub Container Registry and must be built first. Go to your repository on GitHub:
+
+> **Actions** → **Docker Build and Push** → **Run workflow**
+
+This pushes the image to `ghcr.io/your_username/endfield-calc:latest`.
+
+**Step 2: Run with Docker Compose**
+
+Edit `compose.yaml` and replace the placeholder values:
+
+```yaml
+services:
+  endfield-calc:
+    image: ghcr.io/your_username/endfield-calc:latest
+    ports:
+      - "your_port:80"
+    restart: unless-stopped
+```
+
+Then run:
+
+```bash
+docker compose up -d
+```
+
+**Build locally**
+
+If you prefer to build the image on your own machine instead of using GitHub Actions:
+
+```bash
+git clone https://github.com/JamboChen/endfield-calc.git
+cd endfield-calc
+docker compose -f - up -d <<EOF
+services:
+  endfield-calc:
+    build: .
+    ports:
+      - "your_port:80"
+    restart: unless-stopped
+EOF
+```
+
+Or edit `compose.yaml` to replace `image:` with `build: .` and run `docker compose up -d --build`.
 
 Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,9 +58,58 @@ git clone https://github.com/JamboChen/endfield-calc.git
 cd endfield-calc
 pnpm install
 pnpm run dev
-````
+```
 
-## 参与贡献
+### Docker
+
+**第一步：通过 GitHub Actions 构建镜像**
+
+镜像托管在 GitHub Container Registry，需先触发构建。在 GitHub 仓库页面操作：
+
+> **Actions** → **Docker Build and Push** → **Run workflow**
+
+构建完成后镜像会推送至 `ghcr.io/your_username/endfield-calc:latest`。
+
+**第二步：使用 Docker Compose 运行**
+
+编辑 `compose.yaml`，替换其中的占位符：
+
+```yaml
+services:
+  endfield-calc:
+    image: ghcr.io/your_username/endfield-calc:latest
+    ports:
+      - "your_port:80"
+    restart: unless-stopped
+```
+
+然后运行：
+
+```bash
+docker compose up -d
+```
+
+
+**本地构建镜像**
+
+如果不想使用 GitHub Actions，也可以在本地直接构建：
+
+将 `compose.yaml` 中的 `image:` 替换为 `build: .`：
+
+```yaml
+services:
+  endfield-calc:
+    build: .
+    ports:
+      - "your_port:80"
+    restart: unless-stopped
+```
+
+然后运行：
+
+```bash
+docker compose up -d --build
+```
 
 欢迎任何形式的贡献！请参阅 [CONTRIBUTING.md](CONTRIBUTING.md) 了解详细规范。
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   endfield-calc:
-    image: ghcr.io/jambochen/endfield-calc:latest
+    image: ghcr.io/your_username/endfield-calc:latest
     ports:
-      - "8080:80"
+      - "your_port:80"
     restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  endfield-calc:
+    image: ghcr.io/jambochen/endfield-calc:latest
+    ports:
+      - "8080:80"
+    restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    # Redirect root to the app base path
+    location = / {
+        return 301 /endfield-calc/;
+    }
+
+    # Serve the SPA — all unmatched routes fall back to index.html
+    location /endfield-calc/ {
+        try_files $uri $uri/ /endfield-calc/index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Summary

Adds Docker deployment support so users can self-host the app via a pre-built image from GitHub Container Registry or by building locally.

## What changed

- **`Dockerfile`** — Multi-stage build: `node:22-alpine` builds the app with pnpm 9, `nginx:alpine` serves the static output under `/endfield-calc/`.
- **`nginx.conf`** — SPA routing fallback for the `/endfield-calc/` sub-path, static asset caching.
- **`compose.yaml`** — Template compose file referencing `ghcr.io/your_username/endfield-calc:latest` on a configurable port.
- **`.dockerignore`** — Excludes `node_modules`, `dist`, `.git`, etc. from the build context.
- **`.github/workflows/docker.yml`** — New GitHub Actions workflow that builds and pushes a multi-arch image (`linux/amd64`, `linux/arm64`) to ghcr.io on every Release, with `workflow_dispatch` for manual runs. Semver tags (`x.y.z`, `x.y`, `latest`) are applied automatically.
- **`README.md` / `README_zh.md`** — New Docker section documenting both the GitHub Actions image and the local build path.

## Coverage

- Both `amd64` and `arm64` architectures are supported (Apple Silicon, Raspberry Pi, etc.).
- GitHub Actions layer cache (`type=gha`) is enabled to speed up subsequent builds.
- The existing app logic and data are unaffected — this PR adds no changes to calculation or game data.

## Disambiguation

The `compose.yaml` ships as a user-editable template with placeholder values (`your_username`, `your_port`) rather than hardcoded values, since each self-hoster will have their own fork and preferred port.