### PR TITLE
Add: GitHub Pages beta channel for master at /endfield-calc/beta/

### DIFF
--- a/.claude/rules/domain-settings.md
+++ b/.claude/rules/domain-settings.md
@@ -54,6 +54,7 @@ Region-exclusive **map structures** the user opts into (not roster/AIC buildings
 
 ## Persistence (verified)
 
+- **Channel namespacing**: every localStorage key in this file is the *base* (production) value. Beta builds (served at `/endfield-calc/beta/`) suffix all keys with `:beta` via `namespaceStorageKey` (`src/lib/storage-namespace.ts`), so on beta these become `endfield-calc:aic-v1:beta` and `endfield-calc:onboarding-v1:beta`. The two channels share an origin and would otherwise collide. New persisted keys MUST go through `namespaceStorageKey` for the same reason.
 - Sole version signal: localStorage key `endfield-calc:aic-v1` (line 96). No `v` field inside the JSON.
 - Loader detects shape (line 217-224): nested `{ domains, aic }` is current; flat `{ unresearched, capOverrides, inactiveDomains? }` is v1, migrated in-memory and re-written nested on next save.
 - AIC sub-state uses a **deny-list** for research (`aic.unresearched`); domains use a **deny-list** for activation (`domains.inactive`). `rawLimits.overrides` + `structures.enabled` are **allow-lists** (optional keys; absent in older payloads).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,26 @@
-# Deploy static content to GitHub Pages on release
+# Deploy static content to GitHub Pages
+#
+# Two channels:
+#   * Production (https://JamboChen.github.io/endfield-calc/) is built
+#     from the latest annotated release tag reachable from master.
+#   * Beta      (https://JamboChen.github.io/endfield-calc/beta/) is built
+#     from the current master HEAD with --base /endfield-calc/beta/.
+#
+# GitHub Pages deployments are atomic per repo, so both channels are
+# packaged into a single artifact and shipped in one deploy step.
 name: Deploy static content to Pages
 
 on:
-  # Runs when a new release is published
+  # New stable release published -> rebuild prod + refresh beta.
   release:
     types: [published]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Master commits -> rebuild beta (and rebuild prod from latest tag,
+  # which is a no-op as long as the tag's source hasn't moved).
+  push:
+    branches: [master]
+
+  # Manual re-trigger from the Actions tab.
   workflow_dispatch:
 
 # Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
@@ -15,23 +29,25 @@ permissions:
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
+# Allow one deployment at a time, but queue rather than cancel so a
+# master push during an in-flight release deploy ships both serially.
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout master
         uses: actions/checkout@v5
         with:
-          # Fetch all history and tags for version detection
+          ref: master
+          # Full history + tags so `git describe` can resolve the
+          # latest release tag for the production build below.
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -39,22 +55,48 @@ jobs:
         with:
           version: 10
           run_install: false
+
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: "pnpm"
-      - name: Install dependencies
+
+      - name: Detect latest release tag
+        id: tag
+        run: echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+      # --- Build production from the latest release tag into dist/ ---
+      # Order matters: prod first so its --emptyOutDir wipes dist/ clean;
+      # beta second so its --emptyOutDir only clears dist/beta/, leaving
+      # the prod files alongside intact.
+      - name: Checkout latest release tag
+        run: git checkout ${{ steps.tag.outputs.tag }}
+
+      - name: Install dependencies (release)
         run: pnpm install
-      - name: Build
+
+      - name: Build release into dist/
         run: pnpm build
+
+      # --- Build beta from master into dist/beta/ ---
+      - name: Switch back to master
+        run: git checkout master
+
+      - name: Install dependencies (master)
+        run: pnpm install
+
+      - name: Build beta into dist/beta/
+        run: pnpm build:beta
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          # Upload dist folder
           path: "./dist"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:beta": "tsc -b && vite build --base /endfield-calc/beta/ --outDir dist/beta --emptyOutDir",
     "lint": "eslint .",
     "preview": "vite preview",
     "knip": "knip",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /endfield-calc/beta/
 
 Sitemap: https://JamboChen.github.io/endfield-calc/sitemap.xml

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import {
 } from "./data";
 import { parseRawLimitKey } from "./lib/raw-limits-helpers";
 import { structureKey } from "./lib/settings-helpers";
+import { namespaceStorageKey } from "./lib/storage-namespace";
 import type { FacilityId, ItemId } from "./types";
 
 /**
@@ -416,7 +417,7 @@ function AppContent() {
 
 export default function App() {
   return (
-    <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+    <ThemeProvider defaultTheme="light" storageKey={namespaceStorageKey("vite-ui-theme")}>
       <DomainSettingsProvider>
         <TooltipProvider>
           <AppContent />

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -41,6 +41,14 @@ export default function AppFooter() {
           <span className="text-muted-foreground/60">•</span>
           <span>{t("footer.unofficial")}</span>
           <span className="text-muted-foreground/60">•</span>
+          {import.meta.env.BASE_URL.includes("/beta/") && (
+            <>
+              <span className="font-mono uppercase tracking-wider text-[10px] px-1.5 py-0.5 rounded border border-amber-500/40 text-amber-600 dark:text-amber-400">
+                Beta
+              </span>
+              <span className="text-muted-foreground/60">•</span>
+            </>
+          )}
           <span className="font-mono">{__APP_VERSION__}</span>
         </div>
       </div>

--- a/src/components/onboarding/AicOnboardingDialog.tsx
+++ b/src/components/onboarding/AicOnboardingDialog.tsx
@@ -83,10 +83,11 @@ import {
 } from "@/components/ui/select";
 import { useDomainSettingsContext } from "@/contexts/domain-settings-context";
 import { pickLatestActive } from "@/hooks/useDomainSettings";
+import { namespaceStorageKey } from "@/lib/storage-namespace";
 import { cn } from "@/lib/utils";
 import type { Domain, DomainId } from "@/types/domain";
 
-const STORAGE_KEY = "endfield-calc:onboarding-v1";
+const STORAGE_KEY = namespaceStorageKey("endfield-calc:onboarding-v1");
 
 export function AicOnboardingDialog() {
   const { t } = useTranslation(["onboarding", "domain"]);

--- a/src/hooks/useDomainSettings.ts
+++ b/src/hooks/useDomainSettings.ts
@@ -147,6 +147,7 @@ import {
   structureKey,
   structuresDisabledFromEnabled,
 } from "@/lib/settings-helpers";
+import { namespaceStorageKey } from "@/lib/storage-namespace";
 import type {
   AicGroupId,
   AicLayerId,
@@ -157,7 +158,7 @@ import type { Domain, DomainId } from "@/types/domain";
 import type { FacilityId, ItemId } from "@/types";
 import type { RegionStructureId } from "@/types/constants";
 
-const STORAGE_KEY = "endfield-calc:aic-v1";
+const STORAGE_KEY = namespaceStorageKey("endfield-calc:aic-v1");
 
 interface CapOverrideRecord {
   facilityId: FacilityId;

--- a/src/lib/storage-namespace.ts
+++ b/src/lib/storage-namespace.ts
@@ -1,0 +1,39 @@
+/**
+ * localStorage key namespacing for the beta channel.
+ *
+ * Beta builds (served at `/endfield-calc/beta/`) share the same origin
+ * as production (`/endfield-calc/`), so without namespacing every
+ * persisted key would collide between channels. A schema change on
+ * beta could then corrupt prod state and vice-versa.
+ *
+ * This helper suffixes any base key with `:beta` when the runtime base
+ * path indicates a beta build, otherwise returns the key untouched.
+ * Production users continue reading and writing the unsuffixed keys
+ * exactly as before — only beta gets the suffix.
+ *
+ * Vite's `import.meta.env.BASE_URL` is set from the `--base` build
+ * flag (see the `build:beta` script in `package.json`):
+ *
+ *   - Production build: `/endfield-calc/`        -> no suffix
+ *   - Beta build:       `/endfield-calc/beta/`   -> `:beta` suffix
+ *   - Dev / tests:      `/`                      -> no suffix
+ *
+ * First-visit consequence: a user opening the beta channel for the
+ * first time will see the AIC onboarding dialog again and start with
+ * default settings, because the suffixed keys don't exist yet. This
+ * is intentional — the two channels are fully independent.
+ */
+const IS_BETA_CHANNEL = import.meta.env.BASE_URL.includes("/beta/");
+
+/**
+ * Returns the input key suffixed with `:beta` on beta builds, or the
+ * key unchanged on production / dev / test builds.
+ *
+ * @example
+ *   const STORAGE_KEY = namespaceStorageKey("endfield-calc:aic-v1");
+ *   // prod:  "endfield-calc:aic-v1"
+ *   // beta:  "endfield-calc:aic-v1:beta"
+ */
+export function namespaceStorageKey(key: string): string {
+  return IS_BETA_CHANNEL ? `${key}:beta` : key;
+}


### PR DESCRIPTION
## What

Adds a second GitHub Pages deployment channel:

- **`/endfield-calc/`** (production) — unchanged; continues to ship the latest release tag.
- **`/endfield-calc/beta/`** (new) — master HEAD, refreshed on every master push.

Both channels are packed into a single Pages artifact and deployed atomically, satisfying GitHub Pages' one-deploy-per-repo constraint.

## Why

Master commits are invisible to users until a release is cut. This adds a low-friction preview channel so contributors and curious users can try in-progress work in the browser without local setup. Production users see no change.

## How

The existing deploy workflow gains a second trigger (`push: master`) and a dual-build step. On every run (release publish OR master push):

1. Detect the latest release tag from master via `git describe --tags --abbrev=0`.
2. Checkout that tag → `pnpm install` → `pnpm build` → emits `dist/`.
3. Checkout master → `pnpm install` → `pnpm build:beta` → emits `dist/beta/`.
4. Upload combined `dist/` as the Pages artifact, deploy.

Build order is deliberate: prod first (its `emptyOutDir` wipes `dist/` clean), beta second (only clears `dist/beta/`).

`concurrency.cancel-in-progress` flips from `true` → `false` so a master push during an in-flight release deploy queues serially rather than cancelling.

## Files

| File | Change |
|---|---|
| `package.json` | New `build:beta` script (`vite build --base /endfield-calc/beta/ --outDir dist/beta --emptyOutDir`) |
| `.github/workflows/deploy.yml` | Extended trigger, dual-build pipeline, concurrency change |
| `src/components/layout/AppFooter.tsx` | Small amber `BETA` chip gated on `import.meta.env.BASE_URL.includes('/beta/')` — dead-code-eliminated on prod builds |
| `public/robots.txt` | `Disallow: /endfield-calc/beta/` so search engines don't index two copies |
| `src/lib/storage-namespace.ts` *(new)* | Helper that suffixes localStorage keys with `:beta` on beta builds, so schema drift on beta can't corrupt prod state |
| `src/hooks/useDomainSettings.ts`, `src/components/onboarding/AicOnboardingDialog.tsx`, `src/App.tsx` | Route the 3 existing localStorage keys through the helper |
| `.claude/rules/domain-settings.md` | Document the channel-namespacing convention |

## Behaviour notes

- **First-visit beta UX**: users see the AIC onboarding dialog on beta because `endfield-calc:onboarding-v1:beta` doesn't exist yet. Intentional — channels are fully independent.
- **Theme / settings**: beta uses `vite-ui-theme:beta`, `endfield-calc:aic-v1:beta`, `endfield-calc:onboarding-v1:beta`. Prod keys untouched.
- **Footer**: beta shows amber `BETA` chip + post-tag version (`v0.7.0-N-gSHA`).
- **CI cost**: each master push adds ~30–45s on top of the existing release-only deploy (one extra `pnpm install` + one extra Vite build).

## Live validation

Tested end-to-end on my fork:

- Prod (built from v0.7.0): https://lsequeiraa.github.io/endfield-calc/
- Beta (built from master HEAD): https://lsequeiraa.github.io/endfield-calc/beta/
- Deploy run: https://github.com/lsequeiraa/endfield-calc/actions/runs/26791867989 (44s, all 17 steps green)

Verified:
- Both URLs 200; asset paths fully isolated (prod → `/endfield-calc/assets/`, beta → `/endfield-calc/beta/assets/`, no cross-references).
- `highs.wasm` 200s under the beta `assets/`. (Prod 404s on the fork because v0.7.0 predates PR #81's HiGHS migration — irrelevant for this PR.)
- Beta minified JS contains the namespacing helper inlined: a module-scope const checks `"/endfield-calc/beta/".includes("/beta/")` (true at runtime), a wrapper appends `:beta` to its argument when that const is true, and the persisted keys are emitted as wrapper calls (e.g., `el = wrapper("endfield-calc:aic-v1")`). Verified via curl + grep on the minified bundle.
- Beta `robots.txt` carries the `Disallow` line.
- `bun run lint` clean of new warnings, `bun vitest run` 457/457 pass.

## First deploy after merge

GitHub will auto-create the `github-pages` environment with a default policy allowing the default branch. The first master push after merging will deploy without manual setup. To make beta live immediately, trigger `workflow_dispatch` from the Actions tab after merging.

The first run rebuilds v0.7.0 for prod (no visible change for prod users) and master HEAD for beta. Until the next release tag includes PR #81, prod's `highs.wasm` will continue to 404 — but this is unchanged from current production.

## Reverting

If you want to remove the beta channel later, simply revert this PR. The next deploy will ship only `dist/` again. Beta-only localStorage keys (`:beta` suffixed) remain inert and don't interfere with prod.
